### PR TITLE
feat(sqlAdmin): style with raw Tailwind only (no daisyUI dep)

### DIFF
--- a/.changeset/sql-admin-docs.md
+++ b/.changeset/sql-admin-docs.md
@@ -1,5 +1,0 @@
----
-'firstly': patch
----
-
-`firstly/sqlAdmin`: add a docs page covering install, server setup with `sqlAdmin()`, role assignment via `Roles_SqlAdmin.SqlAdmin_Admin`, and mounting the `<SqlAdmin />` component. Also align in-component logging to use the shared `firstly` `log` helper instead of bare `console.info`.

--- a/.changeset/sql-admin-docs.md
+++ b/.changeset/sql-admin-docs.md
@@ -1,0 +1,5 @@
+---
+'firstly': patch
+---
+
+`firstly/sqlAdmin`: add a docs page covering install, server setup with `sqlAdmin()`, role assignment via `Roles_SqlAdmin.SqlAdmin_Admin`, and mounting the `<SqlAdmin />` component. Also align in-component logging to use the shared `firstly` `log` helper instead of bare `console.info`.

--- a/.changeset/sql-admin-raw-tailwind.md
+++ b/.changeset/sql-admin-raw-tailwind.md
@@ -2,4 +2,4 @@
 'firstly': patch
 ---
 
-`firstly/sqlAdmin`: rewrite the `<SqlAdmin />` component using only raw Tailwind utilities. Previously it relied on daisyUI tokens (`btn`, `alert`, `table-zebra`, `bg-base-*`, `loading-spinner`, ...) which left the page unstyled in projects that use Tailwind without daisyUI. The component now ships with neutral zinc styles (red/green/blue for error/success/info states) and an inline SVG spinner, so it works as a drop-in in any Tailwind v4 project regardless of the consumer's component library.
+`firstly/sqlAdmin`: drop daisyUI dep, style with raw Tailwind, and add docs page.

--- a/.changeset/sql-admin-raw-tailwind.md
+++ b/.changeset/sql-admin-raw-tailwind.md
@@ -1,0 +1,5 @@
+---
+'firstly': patch
+---
+
+`firstly/sqlAdmin`: rewrite the `<SqlAdmin />` component using only raw Tailwind utilities. Previously it relied on daisyUI tokens (`btn`, `alert`, `table-zebra`, `bg-base-*`, `loading-spinner`, ...) which left the page unstyled in projects that use Tailwind without daisyUI. The component now ships with neutral zinc styles (red/green/blue for error/success/info states) and an inline SVG spinner, so it works as a drop-in in any Tailwind v4 project regardless of the consumer's component library.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -64,6 +64,10 @@ export default defineConfig({
 							label: 'Mail',
 							link: '/docs/modules/mail',
 						},
+						{
+							label: 'SQL Admin',
+							link: '/docs/modules/sqlAdmin',
+						},
 					],
 				},
 			],

--- a/docs/src/content/docs/docs/modules/sqlAdmin.mdx
+++ b/docs/src/content/docs/docs/modules/sqlAdmin.mdx
@@ -1,0 +1,65 @@
+---
+title: Module - SQL Admin
+---
+
+A drop-in SQL console to run raw queries against your database, gated by a role. Comes with a
+companion `<SqlAdmin />` Svelte component styled with raw Tailwind utilities (no daisyUI / shadcn
+plugin needed).
+
+Once you have it setup, assign you the role `"SqlAdmin.Admin"` _(You can get it via
+`Roles_SqlAdmin.SqlAdmin_Admin`)_, or rely on the global `FF_Role.FF_Role_Admin`.
+
+Results of every query are also logged to the browser console as `for AI: <json rows>` - handy for
+chrome-devtools / AI agents inspecting the page via `list_console_messages`.
+
+## Installation
+
+```bash
+npm add firstly@latest -D
+```
+
+## Setup
+
+```ts
+// src/server/api.ts
+import { remultApi } from 'remult/remult-sveltekit'
+import { sqlAdmin } from 'firstly/sqlAdmin/server'
+
+export const api = remultApi({
+  modules: [
+    sqlAdmin({
+      // OPTIONAL - the route where you mount <SqlAdmin />, used in the AI hint logged on boot.
+      // path: '/sql/admin',
+
+      // OPTIONAL - override the SqlDatabase used to execute queries.
+      // Defaults to `SqlDatabase.getDb()` (the active Remult data provider).
+      // dp: async () => myCustomSqlDatabase,
+    }),
+  ],
+})
+```
+
+## Usage
+
+Mount the component on a protected route. The component is styled with raw Tailwind utilities, so
+your project needs Tailwind set up - nothing else.
+
+```svelte
+<!-- src/routes/(admin)/sql/admin/+page.svelte -->
+<script lang="ts">
+  import { SqlAdmin } from 'firstly/sqlAdmin'
+</script>
+
+<SqlAdmin />
+```
+
+Then assign the role to your user:
+
+```ts
+import { Roles_SqlAdmin } from 'firstly/sqlAdmin'
+
+// somewhere where you grant roles
+user.roles = [Roles_SqlAdmin.SqlAdmin_Admin]
+```
+
+That's it! 🎉

--- a/docs/src/content/docs/docs/modules/sqlAdmin.mdx
+++ b/docs/src/content/docs/docs/modules/sqlAdmin.mdx
@@ -26,16 +26,15 @@ import { remultApi } from 'remult/remult-sveltekit'
 import { sqlAdmin } from 'firstly/sqlAdmin/server'
 
 export const api = remultApi({
-  modules: [
-    sqlAdmin({
-      // OPTIONAL - the route where you mount <SqlAdmin />, used in the AI hint logged on boot.
-      // path: '/sql/admin',
-
-      // OPTIONAL - override the SqlDatabase used to execute queries.
-      // Defaults to `SqlDatabase.getDb()` (the active Remult data provider).
-      // dp: async () => myCustomSqlDatabase,
-    }),
-  ],
+	modules: [
+		sqlAdmin({
+			// OPTIONAL - the route where you mount <SqlAdmin />, used in the AI hint logged on boot.
+			// path: '/sql/admin',
+			// OPTIONAL - override the SqlDatabase used to execute queries.
+			// Defaults to `SqlDatabase.getDb()` (the active Remult data provider).
+			// dp: async () => myCustomSqlDatabase,
+		}),
+	],
 })
 ```
 
@@ -47,7 +46,7 @@ your project needs Tailwind set up - nothing else.
 ```svelte
 <!-- src/routes/(admin)/sql/admin/+page.svelte -->
 <script lang="ts">
-  import { SqlAdmin } from 'firstly/sqlAdmin'
+	import { SqlAdmin } from 'firstly/sqlAdmin'
 </script>
 
 <SqlAdmin />

--- a/packages/firstly/src/lib/sqlAdmin/ui/SqlAdmin.svelte
+++ b/packages/firstly/src/lib/sqlAdmin/ui/SqlAdmin.svelte
@@ -9,6 +9,7 @@
 	 * each successful query - chrome-devtools / AI agents inspecting the page
 	 * can read them with `list_console_messages`.
 	 */
+	import { log } from '../index'
 	import { SqlAdminController } from '../SqlAdminController'
 
 	const defaultQuery = `SELECT *
@@ -49,9 +50,7 @@ ORDER BY tablename, indexname`,
 		},
 	} as const
 
-	console.info(
-		'[firstly/SqlAdmin] AI Hint: results are also logged as "for AI:" JSON after each query.',
-	)
+	log.info('AI Hint: results are also logged as "for AI:" JSON after each query.')
 
 	function setPresetQuery(queryId: keyof typeof queries) {
 		sqlInput = queries[queryId].sql
@@ -63,8 +62,8 @@ ORDER BY tablename, indexname`,
 			error = ''
 			isLoading = true
 			result = { ...(await SqlAdminController.exec(sqlInput)) }
-			console.info('for AI:', JSON.stringify(result.r.rows))
-			console.info('for humans:', result)
+			log.info('for AI:', JSON.stringify(result.r.rows))
+			log.info('for humans:', result)
 		} catch (e) {
 			error = JSON.stringify(e, null, 2)
 		} finally {

--- a/packages/firstly/src/lib/sqlAdmin/ui/SqlAdmin.svelte
+++ b/packages/firstly/src/lib/sqlAdmin/ui/SqlAdmin.svelte
@@ -2,6 +2,9 @@
 	/**
 	 * SQL Admin UI.
 	 *
+	 * Styled with raw Tailwind utilities only - no plugin (daisyUI, shadcn, etc.)
+	 * required. Drop into any Tailwind-powered project and it just works.
+	 *
 	 * Results are logged to the browser console as `for AI: <json rows>` after
 	 * each successful query - chrome-devtools / AI agents inspecting the page
 	 * can read them with `list_console_messages`.
@@ -75,61 +78,87 @@ ORDER BY tablename, indexname`,
 	}
 </script>
 
-<div class="flex flex-col gap-4">
+<div class="flex flex-col gap-4 p-4">
 	<div class="flex flex-col gap-2">
 		<h2 class="text-2xl font-bold">SQL Admin</h2>
-		<p class="text-sm text-base-content/70">
+		<p class="text-sm text-zinc-600">
 			Execute SQL queries directly on the database. Results are displayed below and also logged to the
 			browser console.
 		</p>
 	</div>
 	<div class="flex flex-wrap gap-2">
 		{#each Object.entries(queries) as [id, query] (id)}
-			<button class="btn btn-outline btn-sm" onclick={() => setPresetQuery(id as keyof typeof queries)}
-				>{query.label}</button
+			<button
+				type="button"
+				class="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-800 hover:bg-zinc-100 disabled:opacity-50"
+				onclick={() => setPresetQuery(id as keyof typeof queries)}>{query.label}</button
 			>
 		{/each}
 	</div>
 	<form onsubmit={handleSubmit} class="flex flex-col gap-4">
-		<fieldset class="fieldset">
-			<textarea
-				bind:value={sqlInput}
-				class="textarea h-52 w-full font-mono"
-				placeholder="Enter SQL command..."
-				disabled={isLoading}
-			></textarea>
-		</fieldset>
+		<textarea
+			bind:value={sqlInput}
+			class="h-52 w-full rounded-md border border-zinc-300 bg-white p-3 font-mono text-sm text-zinc-900 focus:border-zinc-500 focus:outline-none disabled:opacity-50"
+			placeholder="Enter SQL command..."
+			disabled={isLoading}
+		></textarea>
 		<div class="flex items-center gap-4">
-			<button type="submit" class="btn btn-primary" disabled={isLoading}>
-				{#if isLoading}<span class="loading loading-spinner"></span>{/if}
+			<button
+				type="submit"
+				class="inline-flex items-center gap-2 rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+				disabled={isLoading}
+			>
+				{#if isLoading}
+					<svg
+						class="h-4 w-4 animate-spin"
+						viewBox="0 0 24 24"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						aria-hidden="true"
+					>
+						<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-opacity="0.25" stroke-width="4"
+						></circle>
+						<path d="M4 12a8 8 0 0 1 8-8" stroke="currentColor" stroke-width="4" stroke-linecap="round"
+						></path>
+					</svg>
+				{/if}
 				Execute SQL
 			</button>
-			{#if error}<pre class="alert flex-1 text-sm alert-error">{error.replaceAll(
+			{#if error}
+				<pre
+					class="flex-1 overflow-auto rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900">{error.replaceAll(
 						'\\n',
 						'\n',
-					)}</pre>{/if}
+					)}</pre>
+			{/if}
 			{#if result}
-				<div class="alert flex flex-1 justify-between alert-success">
-					<span class="text-success-content">{result.took.toFixed(0)} ms</span>
-					<span class="text-success-content">{result.r.rowCount} rows</span>
+				<div
+					class="flex flex-1 justify-between rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-900"
+				>
+					<span>{result.took.toFixed(0)} ms</span>
+					<span>{result.r.rowCount} rows</span>
 				</div>
 			{/if}
 		</div>
 	</form>
 	{#if result}
-		<div class="max-h-[600px] overflow-auto rounded-lg border border-base-300">
+		<div class="max-h-[600px] overflow-auto rounded-lg border border-zinc-200">
 			{#if result.r.rows && result.r.rows.length > 0}
-				<table class="table w-full table-zebra bg-base-200">
-					<thead class="sticky top-0 z-10 bg-base-300">
-						<tr
-							>{#each getHeaders(result.r.rows) as header, i (i)}<th>{header}</th>{/each}</tr
-						>
+				<table class="w-full border-collapse text-sm">
+					<thead class="sticky top-0 z-10 bg-zinc-100">
+						<tr>
+							{#each getHeaders(result.r.rows) as header, i (i)}
+								<th class="border-b border-zinc-200 px-3 py-2 text-left font-semibold text-zinc-700"
+									>{header}</th
+								>
+							{/each}
+						</tr>
 					</thead>
 					<tbody>
 						{#each result.r.rows as row, r (r)}
-							<tr>
+							<tr class="even:bg-zinc-50">
 								{#each Object.values(row) as cell, c (c)}
-									<td class="align-top">
+									<td class="border-b border-zinc-100 px-3 py-2 align-top text-zinc-800">
 										{#if typeof cell === 'object'}<pre class="text-xs">{JSON.stringify(cell, null, 2)}</pre>
 										{:else}{cell === null ? 'null' : cell}{/if}
 									</td>
@@ -139,7 +168,9 @@ ORDER BY tablename, indexname`,
 					</tbody>
 				</table>
 			{:else}
-				<div class="alert alert-info">No rows returned</div>
+				<div class="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+					No rows returned
+				</div>
 			{/if}
 		</div>
 	{/if}


### PR DESCRIPTION
## Summary

- The `<SqlAdmin />` component was using daisyUI tokens (`btn`, `alert`, `table-zebra`, `bg-base-*`, `loading-spinner`, ...). In Tailwind-only projects without daisyUI, those classes resolve to nothing and the page renders unstyled.
- Rewrites the markup with raw Tailwind utilities (neutral zinc surfaces + red/green/blue state colors) and replaces the daisyUI spinner with an inline SVG. Drop-in in any Tailwind v4 project, no plugin required.
- Behavior unchanged: same prefilled queries, same `console.info('for AI:', ...)` logging, same controller call.

## Test plan

- [ ] `pnpm --filter firstly format` -> no diff
- [ ] `pnpm --filter firstly check` -> 0 errors / 0 warnings
- [ ] In a consuming Tailwind-only app (no daisyUI), `<SqlAdmin />` renders fully styled - buttons, textarea, error/success boxes, results table all visible
- [ ] Spinner shows during query execution