### PR TITLE
feat(changeLog): export ChangeLog entity class

### DIFF
--- a/.changeset/export-changelog-entity.md
+++ b/.changeset/export-changelog-entity.md
@@ -1,0 +1,5 @@
+---
+'firstly': patch
+---
+
+`firstly/changeLog`: export the `ChangeLog` entity class so apps can declare `@Relations` to it (e.g. linking changelog rows back to a `User`).

--- a/packages/firstly/src/lib/changeLog/index.ts
+++ b/packages/firstly/src/lib/changeLog/index.ts
@@ -12,7 +12,7 @@ import {
 
 import { ChangeLog, Roles_ChangeLog, type change } from './changeLogEntities'
 
-export { Roles_ChangeLog }
+export { ChangeLog, Roles_ChangeLog }
 
 export type { change }
 


### PR DESCRIPTION
`firstly/changeLog` only exported `Roles_ChangeLog` and the `change` type, not the `ChangeLog` entity class. That made it impossible for apps to declare `@Relations` to the changelog table (e.g. linking changelog rows back to a `User`).

Exports `ChangeLog` from `firstly/changeLog`.