### PR TITLE
feat(mail): store attachments count in Mail.metadata

### DIFF
--- a/.changeset/mail-meta-attachments.md
+++ b/.changeset/mail-meta-attachments.md
@@ -1,0 +1,5 @@
+---
+'firstly': patch
+---
+
+mail: store `attachments` count in `Mail.metadata` so the admin UI can show how many files were sent.

--- a/packages/firstly/src/lib/mail/server/index.ts
+++ b/packages/firstly/src/lib/mail/server/index.ts
@@ -154,6 +154,10 @@ export const sendMail: (
 	title = title ?? subject ?? 'subject'
 	footer = footer ?? 'The team wishes you a great day 🚀'
 
+	const mergedAttachments =
+		options?.nodemailer?.defaults?.attachments ?? globalOptions?.nodemailer?.defaults?.attachments
+	const attachments = Array.isArray(mergedAttachments) ? mergedAttachments.length : 0
+
 	const metadata = {
 		service,
 		primaryColor,
@@ -164,6 +168,7 @@ export const sendMail: (
 		sections,
 		cc,
 		bcc,
+		attachments,
 	}
 	const html = easyOptionsToUse.toHtml ? easyOptionsToUse.toHtml(metadata) : toHtml(metadata)
 


### PR DESCRIPTION
## Summary

- Adds `attachments: number` (count only) to `Mail.metadata` so the admin UI can show how many files were sent, alongside the existing `cc` / `bcc`.
- Read from the merged `nodemailer.defaults.attachments` (per-call > global). Never stores Buffer payloads.

## Test plan

- [ ] `sendMail` with attachments → `Mail.metadata.attachments` equals the array length.
- [ ] `sendMail` without attachments → `Mail.metadata.attachments` is `0`.