### PR TITLE
fix(carbone): export Roles_Carbon correctly + expose carbone/changeLog symbols

### DIFF
--- a/.changeset/carbone-roles-and-exports.md
+++ b/.changeset/carbone-roles-and-exports.md
@@ -1,0 +1,7 @@
+---
+'firstly': patch
+---
+
+fix(carbone): export `Roles_Carbon` under its real name (was wrongly aliased to `Roles_Mail`, colliding with `firstly/mail`).
+
+Also expose `CarboneController` and the carbone entity classes from `firstly/carbone`, and `changeLogEntities` from `firstly/changeLog`, so consumers no longer need deep file imports.

--- a/packages/firstly/src/lib/carbone/index.ts
+++ b/packages/firstly/src/lib/carbone/index.ts
@@ -2,7 +2,9 @@ import { Log } from '@kitql/helpers'
 
 import { CarboneLog, CarboneTemplate } from './carboneEntities'
 
-export { Roles_Carbon as Roles_Mail } from './Roles_Carbon'
+export { Roles_Carbon } from './Roles_Carbon'
+export { CarboneController } from './CarboneController'
+export { CarbonLogAction, CarboneTemplate, CarboneLog } from './carboneEntities'
 
 export const key = 'carbone'
 

--- a/packages/firstly/src/lib/changeLog/index.ts
+++ b/packages/firstly/src/lib/changeLog/index.ts
@@ -10,9 +10,9 @@ import {
 	type LifecycleEvent,
 } from 'remult'
 
-import { ChangeLog, Roles_ChangeLog, type change } from './changeLogEntities'
+import { ChangeLog, changeLogEntities, Roles_ChangeLog, type change } from './changeLogEntities'
 
-export { ChangeLog, Roles_ChangeLog }
+export { ChangeLog, Roles_ChangeLog, changeLogEntities }
 
 export type { change }
 


### PR DESCRIPTION
`firstly/carbone` re-exported `Roles_Carbon` aliased as `Roles_Mail`, colliding with the real `Roles_Mail` from `firstly/mail` (two different objects, same exported name). Now exported under its own name.

Also re-exports from the public barrels so consumers avoid deep file imports:
- `firstly/carbone`: `CarboneController`, `CarbonLogAction`, `CarboneTemplate`, `CarboneLog`
- `firstly/changeLog`: `changeLogEntities`

`pnpm -F firstly check` passes (0 errors). Patch changeset included (-> 0.4.4).