### PR TITLE
fix(core): emit FF_Entity .d.ts (explicit return type)

### DIFF
--- a/.changeset/ff-entity-dts.md
+++ b/.changeset/ff-entity-dts.md
@@ -1,0 +1,7 @@
+---
+'firstly': patch
+---
+
+fix(core): add explicit return type to `FF_Entity` so its `.d.ts` is emitted.
+
+The inferred return type referenced a non-portable remult internal, so svelte-package silently skipped generating `FF_Entity.d.ts`. Consumers using the published package got `FF_Entity` typed as `any`, which made every entity option callback (`saving`, `displayValue`, ...) implicitly `any`.

--- a/packages/firstly/src/lib/core/FF_Entity.ts
+++ b/packages/firstly/src/lib/core/FF_Entity.ts
@@ -7,6 +7,6 @@ export function FF_Entity<entityType>(
 	options?: EntityOptions<
 		entityType extends new (...args: any) => any ? InstanceType<entityType> : entityType
 	>,
-) {
+): ReturnType<typeof Entity<entityType>> {
 	return Entity(key, withChangeLog({ ...options }))
 }


### PR DESCRIPTION
`FF_Entity`'s inferred return type referenced a non-portable remult internal, so `svelte-package` silently skipped generating `core/FF_Entity.d.ts`. The published package shipped `FF_Entity.js` with **no types**, so consumers got `FF_Entity` as `any` and every entity option callback (`saving`, `displayValue`, ...) became implicitly `any`.

Fix: explicit return type `ReturnType<typeof Entity<entityType>>`.

Verified:
- `pnpm -F firstly compile` now emits `FF_Entity.d.ts` with the full signature, no "not portable" warnings.
- `pnpm -F firstly check` -> 0 errors.
- Dropping the rebuilt dts into a consumer (my-minion) takes its entity type errors 77 -> 0.

Patch changeset included (-> 0.4.5).