### PR TITLE
refactor(svelte): drop daisyUI, restyle demo with plain Tailwind

### DIFF
--- a/packages/firstly/package.json
+++ b/packages/firstly/package.json
@@ -56,7 +56,6 @@
     "@tailwindcss/vite": "catalog:ui",
     "@typescript/native-preview": "catalog:tooling",
     "@vitest/browser": "catalog:testing",
-    "daisyui": "catalog:ui",
     "eslint": "catalog:kitql",
     "playwright": "catalog:testing",
     "remult": "catalog:best",

--- a/packages/firstly/src/app.css
+++ b/packages/firstly/src/app.css
@@ -1,21 +1,9 @@
 @import 'tailwindcss';
-@plugin 'daisyui' {
-	themes: dim --default;
-	logs: false;
-	/* https://github.com/saadeghi/daisyui/issues/3882 */
-	exclude: properties;
-}
-@plugin 'daisyui/theme' {
-	name: 'firstly';
 
-	--color-primary: oklch(0.5706 0.1796 274.52);
-	--color-secondary: oklch(0.7707 0.1245 74.58);
-	--color-accent: oklch(0.3128 0.0832 314.02);
-}
-
-/* The conventional shadcn-style semantic tokens that firstly's shipped components
-   (FF_DialogManager defaults, sqlAdmin, ...) render against - defined directly here so
-   the showcase shows them correctly. Apps using shadcn tokens already have these. */
+/* Semantic UI tokens (shadcn-style). firstly's shipped headless components
+   (FF_DialogManager, sqlAdmin, ...) render against these names; a consuming app
+   defines its own values so they match its theme. Defined here (dark) so the
+   showcase renders correctly. Apps using shadcn tokens already have these. */
 @theme {
 	--color-background: oklch(0.21 0.006 285.9);
 	--color-foreground: oklch(0.98 0 0);
@@ -24,32 +12,21 @@
 	--color-muted: oklch(0.37 0.01 286);
 	--color-muted-foreground: oklch(0.71 0.01 286);
 	--color-border: oklch(0.44 0.01 286);
+	--color-input: oklch(0.44 0.01 286);
+	--color-ring: oklch(0.55 0.02 286);
+	--color-primary: oklch(0.5706 0.1796 274.52);
 	--color-primary-foreground: oklch(0.98 0 0);
+	--color-secondary: oklch(0.27 0.006 286);
+	--color-secondary-foreground: oklch(0.98 0 0);
+	--color-accent: oklch(0.37 0.01 286);
+	--color-accent-foreground: oklch(0.98 0 0);
 	--color-destructive: oklch(0.58 0.22 27);
 	--color-destructive-foreground: oklch(0.98 0 0);
 }
 
-/* ux: {
-	themes: {
-		light: {
-			primary: colors['orange']['500'],
-			'primary-content': 'white',
-			secondary: colors['blue']['500'],
-			'surface-100': colors['zinc']['800'],
-			'surface-200': colors['zinc']['900'],
-			'surface-300': colors['zinc']['950'],
-			'surface-content': colors['zinc']['100'],
-			'color-scheme': 'light',
-		},
-		dark: {
-			primary: colors['orange']['500'],
-			'primary-content': 'white',
-			secondary: colors['blue']['500'],
-			'surface-100': colors['zinc']['800'],
-			'surface-200': colors['zinc']['900'],
-			'surface-300': colors['zinc']['950'],
-			'surface-content': colors['zinc']['100'],
-			'color-scheme': 'dark',
-		},
-	},
-}, */
+@layer base {
+	body {
+		background-color: var(--color-background);
+		color: var(--color-foreground);
+	}
+}

--- a/packages/firstly/src/app.html
+++ b/packages/firstly/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="firstly">
+<html lang="en">
 	<head>
 		<meta charset="utf-8" />
 

--- a/packages/firstly/src/lib/core/tailwind.ts
+++ b/packages/firstly/src/lib/core/tailwind.ts
@@ -13,11 +13,10 @@ import { twMerge } from 'tailwind-merge'
  * import { tw } from './tailwind'
  *
  * const buttonClasses = tw(
- *   'btn btn-primary',
- *   isDisabled && 'btn-disabled',
- *   size === 'lg' && 'btn-lg'
+ *   'px-4 py-2 bg-primary text-primary-foreground',
+ *   isDisabled && 'opacity-50 pointer-events-none',
+ *   size === 'lg' && 'px-6 text-lg'
  * )
- * // Result: "btn btn-primary btn-disabled" (if isDisabled is true)
  * ```
  */
 export const tw = (...inputs: ClassValue[]) => twMerge(clsx(...inputs))

--- a/packages/firstly/src/lib/virtual/StateDemoEnum.ts
+++ b/packages/firstly/src/lib/virtual/StateDemoEnum.ts
@@ -29,7 +29,7 @@ export class StateDemoEnum extends BaseEnum {
 		caption: 'Delete',
 		icon: {
 			data: LibIcon_Delete,
-			class: 'text-error',
+			class: 'text-destructive',
 		},
 	})
 

--- a/packages/firstly/src/routes/+layout.svelte
+++ b/packages/firstly/src/routes/+layout.svelte
@@ -19,7 +19,9 @@
 	let { children, data }: Props = $props()
 	remult.user = data.user
 
-	const links = [
+	let sidebarOpen = $state(false)
+
+	const links: { path: string; text: string; target?: string }[] = [
 		{ path: route('/'), text: 'Home' },
 		{ path: route('/ff-repo'), text: 'Demo Grid' },
 		{ path: '/dialog', text: 'Dialogs' },
@@ -32,6 +34,8 @@
 		{ path: route('github'), text: '⭐️ firstly', target: '_blank' },
 	]
 
+	const currentLink = $derived(links.find((c) => c.path === $page.url.pathname))
+
 	initRemultSvelteReactivity()
 </script>
 
@@ -39,153 +43,109 @@
 	<title>Firstly</title>
 </svelte:head>
 
-<div class="drawer min-h-screen bg-base-200 lg:drawer-open">
-	<input id="my-drawer" type="checkbox" class="drawer-toggle" />
-	<!-- content -->
-	<main class="drawer-content">
-		<div class="grid grid-cols-12 grid-rows-[min-content] gap-y-12 p-4 lg:gap-x-12 lg:p-10">
-			<!-- header -->
-			<header class="col-span-12 flex items-center gap-2 lg:gap-4">
-				<label for="my-drawer" class="drawer-button btn btn-square btn-ghost lg:hidden">
-					<svg data-src="https://unpkg.com/heroicons/20/solid/bars-3.svg" class="h-5 w-5"></svg>
-				</label>
-				<div class="grow">
-					<h1 class="lg:text-2xl lg:font-light">
-						{links.find((c) => c.path === $page.url.pathname)?.text ??
-							$page.url.pathname.replace('/', '')}
-					</h1>
-				</div>
-				<div>
-					<input type="text" placeholder="Search" class="input input-sm max-sm:w-24" />
-				</div>
-				<!-- dropdown -->
-				<div class="dropdown dropdown-end z-10">
-					<div role="menu" tabindex="0" class="btn btn-circle btn-ghost">
-						<div class="indicator">
-							<span class="indicator-item badge badge-xs badge-error"></span>
-							<svg data-src="https://unpkg.com/heroicons/20/solid/bell.svg" class="h-5 w-5"></svg>
-						</div>
-					</div>
-					<ul class="dropdown-content menu mt-3 w-80 rounded-box bg-base-100 p-2 shadow-2xl">
-						<li>
-							<a href="/" class="gap-4">
-								<div class="avatar">
-									<div class="w-8 rounded-full">
-										<img src="https://picsum.photos/80/80?1" alt="one" />
-									</div>
-								</div>
-								<span>
-									<b>New message</b>
-									<br />
-									Alice: Hi, did you get my files?
-								</span>
-							</a>
-						</li>
-						<li>
-							<a href="/" class="gap-4">
-								<div class="avatar">
-									<div class="w-8 rounded-full">
-										<img src="https://picsum.photos/80/80?2" alt="one" />
-									</div>
-								</div>
-								<span>
-									<b>Reminder</b>
-									<br />
-									Your meeting is at 10am
-								</span>
-							</a>
-						</li>
-						<li>
-							<a href="/" class="gap-4">
-								<div class="avatar">
-									<div class="w-8 rounded-full">
-										<img src="https://picsum.photos/80/80?3" alt="one" />
-									</div>
-								</div>
-								<span>
-									<b>New payment</b>
-									<br />
-									Received $2500 from John Doe
-								</span>
-							</a>
-						</li>
-						<li>
-							<a href="/" class="gap-4">
-								<div class="avatar">
-									<div class="w-8 rounded-full">
-										<img src="https://picsum.photos/80/80?4" alt="one" />
-									</div>
-								</div>
-								<span>
-									<b>New payment</b>
-									<br />
-									Received $1900 from Alice
-								</span>
-							</a>
-						</li>
-					</ul>
-				</div>
-				<!-- /dropdown -->
-				<!-- dropdown -->
-				<div class="dropdown dropdown-end z-10">
-					<div role="menu" tabindex="0" class="btn avatar btn-circle btn-ghost">
-						{#if !remult.authenticated()}
-							<div class="w-10 rounded-full bg-red-700"></div>
-						{:else if remult.user?.name === 'Ermin'}
-							<div class="w-10 rounded-full bg-green-700"></div>
-						{:else}
-							<div class="w-10 rounded-full">
-								<img src="https://avatars.githubusercontent.com/u/5312607?v=4" alt="avatar" />
-							</div>
-						{/if}
-					</div>
-				</div>
-				<!-- /dropdown -->
-			</header>
-			<!-- /header -->
+<svelte:window
+	onkeydown={(e) => {
+		if (e.key === 'Escape') sidebarOpen = false
+	}}
+/>
 
-			<div class="col-span-12">
-				{@render children?.()}
+<div class="bg-background text-foreground min-h-screen">
+	<!-- Sidebar (desktop) + drawer (mobile) -->
+	<aside
+		class="border-border bg-card fixed inset-y-0 left-0 z-20 flex w-72 flex-col gap-2 overflow-y-auto border-r px-6 py-10 transition-transform lg:translate-x-0 {sidebarOpen
+			? 'translate-x-0'
+			: '-translate-x-full'}"
+	>
+		<div class="mx-2 mb-4 flex items-center gap-2 font-black">
+			<svg
+				width="28"
+				height="28"
+				viewBox="0 0 1024 1024"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				aria-hidden="true"
+			>
+				<rect x="256" y="670.72" width="512" height="256" rx="128" class="fill-foreground" />
+				<circle cx="512" cy="353.28" r="256" class="fill-foreground" />
+				<circle cx="512" cy="353.28" r="114.688" class="fill-card" />
+			</svg>
+			Firstly
+		</div>
+		<nav class="flex flex-col gap-1">
+			{#each links as link}
+				<a
+					href={link.path}
+					target={link?.target}
+					onclick={() => (sidebarOpen = false)}
+					class="hover:bg-accent hover:text-accent-foreground rounded-md px-3 py-2 text-sm transition-colors {link.path ===
+					$page.url.pathname
+						? 'bg-accent text-accent-foreground font-medium'
+						: ''}"
+				>
+					{link.text}
+				</a>
+			{/each}
+		</nav>
+	</aside>
+
+	<!-- Mobile backdrop -->
+	{#if sidebarOpen}
+		<button
+			aria-label="Close sidebar"
+			class="fixed inset-0 z-10 bg-black/40 lg:hidden"
+			onclick={() => (sidebarOpen = false)}
+		></button>
+	{/if}
+
+	<!-- Main -->
+	<main class="lg:pl-72">
+		<header
+			class="border-border bg-background/80 sticky top-0 z-10 flex items-center gap-4 border-b px-4 py-3 backdrop-blur lg:px-8"
+		>
+			<button
+				type="button"
+				aria-label="Open navigation menu"
+				class="hover:bg-accent hover:text-accent-foreground inline-flex size-9 items-center justify-center rounded-md transition-colors lg:hidden"
+				onclick={() => (sidebarOpen = true)}
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 20 20"
+					fill="currentColor"
+					class="size-5"
+				>
+					<path
+						fill-rule="evenodd"
+						d="M2 4.75A.75.75 0 012.75 4h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 4.75zm0 5A.75.75 0 012.75 9h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 9.75zM2 14.75a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75z"
+						clip-rule="evenodd"
+					/>
+				</svg>
+			</button>
+			<h1 class="grow truncate text-lg font-semibold lg:text-2xl lg:font-light">
+				{currentLink?.text ?? $page.url.pathname.replace('/', '')}
+			</h1>
+			<input
+				type="text"
+				placeholder="Search"
+				class="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring h-9 w-full max-w-48 rounded-md border bg-transparent px-3 py-1 text-sm outline-none focus-visible:ring-2"
+			/>
+			<div class="flex items-center gap-2">
+				{#if !remult.authenticated()}
+					<span class="bg-destructive size-9 rounded-full" aria-label="Not authenticated"></span>
+				{:else}
+					<img
+						src="https://avatars.githubusercontent.com/u/5312607?v=4"
+						alt="avatar"
+						class="size-9 rounded-full"
+					/>
+				{/if}
 			</div>
+		</header>
+
+		<div class="p-4 lg:p-8">
+			{@render children?.()}
 		</div>
 	</main>
-	<!-- /content -->
-	<aside class="drawer-side z-10">
-		<label for="my-drawer" class="drawer-overlay"></label>
-		<!-- sidebar menu -->
-		<nav class="flex min-h-screen w-72 flex-col gap-2 overflow-y-auto bg-base-100 px-6 py-10">
-			<div class="mx-4 flex items-center gap-2 font-black">
-				<svg
-					width="32"
-					height="32"
-					viewBox="0 0 1024 1024"
-					fill="none"
-					xmlns="http://www.w3.org/2000/svg"
-				>
-					<rect x="256" y="670.72" width="512" height="256" rx="128" class="fill-base-content" />
-					<circle cx="512" cy="353.28" r="256" class="fill-base-content" />
-					<circle cx="512" cy="353.28" r="261" stroke="black" stroke-opacity="0.2" stroke-width="10" />
-					<circle cx="512" cy="353.28" r="114.688" class="fill-base-100" />
-				</svg>
-				Firstly
-			</div>
-			<ul class="menu w-full">
-				{#each links as link}
-					<li>
-						<a
-							href={link.path}
-							class={link.path === $page.url.pathname ? 'menu-active' : ''}
-							target={link?.target}
-						>
-							<svg data-src="https://unpkg.com/heroicons/20/solid/home.svg" class="h-5 w-5"></svg>
-							{link.text}
-						</a>
-					</li>
-				{/each}
-			</ul>
-		</nav>
-		<!-- /sidebar menu -->
-	</aside>
 </div>
 
 <!-- firstly headless dialog manager (built-in themeable defaults). -->

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ catalogs:
     clsx:
       specifier: 2.1.1
       version: 2.1.1
-    daisyui:
-      specifier: 5.5.3
-      version: 5.5.3
     tailwind-merge:
       specifier: 3.5.0
       version: 3.5.0
@@ -242,9 +239,6 @@ importers:
       '@vitest/browser':
         specifier: catalog:testing
         version: 3.2.3(playwright@1.60.0)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(vitest@3.2.3)
-      daisyui:
-        specifier: catalog:ui
-        version: 5.5.3
       eslint:
         specifier: catalog:kitql
         version: 10.4.0(jiti@2.6.1)
@@ -2114,9 +2108,6 @@ packages:
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
     engines: {node: '>=12'}
-
-  daisyui@5.5.3:
-    resolution: {integrity: sha512-xcDZlujfSHu3AbwXY1mpl25YXDLyzonsBX1YtiIyhvWGTnVIsX4krD5A7mm6RyiwDRlmKbPvMUPPxivQE4Nsvg==}
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
@@ -6231,8 +6222,6 @@ snapshots:
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
-
-  daisyui@5.5.3: {}
 
   dataloader@1.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,6 @@ catalogs:
   '@tailwindcss/vite': 4.2.2
   tailwind-merge: 3.5.0
   clsx: 2.1.1
-  daisyui: 5.5.3
 
  prod:
   '@types/nodemailer': 8.0.0


### PR DESCRIPTION
daisyUI was a **dev-only** dependency, used only by firstly's own demo shell - it was never shipped, and no consumer imports it from firstly (only my-minion uses daisyUI, via its own dep).

- Restyle the demo `+layout.svelte` with plain Tailwind (same style the other showcase pages already use), no daisyUI classes.
- Define the shadcn-style semantic tokens the shipped headless components (`FF_DialogManager`, `sqlAdmin`) render against directly in `app.css`, replacing daisyUI's theme; drop the now-dead `data-theme`.
- Fix a stray daisy-era `text-error` -> `text-destructive`.

Dark theme and existing colors are preserved. No public API or shipped-dependency change, so no changeset.

Scope is intentionally minimal: this brings only the daisy-removal slice of #245, not its component kit / auth boutique.