### PR TITLE
fix(deps): declare @kitql/helpers as a runtime dependency

### DIFF
--- a/.changeset/kitql-helpers-runtime-dep.md
+++ b/.changeset/kitql-helpers-runtime-dep.md
@@ -1,0 +1,10 @@
+---
+'firstly': patch
+---
+
+fix(deps): declare `@kitql/helpers` as a runtime dependency
+
+`esm/index.js` does `import * as h from '@kitql/helpers'` (and re-exports it /
+builds `ff_Log` from it), but the package only listed it under
+`devDependencies`. Consumers that didn't happen to hoist it got
+`Cannot find module '@kitql/helpers'` at runtime. Moved it into `dependencies`.

--- a/packages/firstly/package.json
+++ b/packages/firstly/package.json
@@ -48,7 +48,6 @@
     }
   },
   "devDependencies": {
-    "@kitql/helpers": "catalog:kitql",
     "@sveltejs/adapter-node": "catalog:sveltekit",
     "@sveltejs/kit": "catalog:sveltekit",
     "@sveltejs/package": "catalog:sveltekit",
@@ -66,6 +65,7 @@
     "vitest": "catalog:testing"
   },
   "dependencies": {
+    "@kitql/helpers": "catalog:kitql",
     "@layerstack/utils": "catalog:prod",
     "@mdi/js": "catalog:ui",
     "@types/nodemailer": "catalog:prod",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
 
   packages/firstly:
     dependencies:
+      '@kitql/helpers':
+        specifier: catalog:kitql
+        version: 0.8.15
       '@layerstack/utils':
         specifier: catalog:prod
         version: 1.0.0
@@ -221,9 +224,6 @@ importers:
         specifier: catalog:tooling
         version: 0.10.4(@typescript-eslint/types@8.59.3)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
     devDependencies:
-      '@kitql/helpers':
-        specifier: catalog:kitql
-        version: 0.8.15
       '@sveltejs/adapter-node':
         specifier: catalog:sveltekit
         version: 5.5.4(@sveltejs/kit@2.46.5(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.40.0)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.40.0)(vite@7.3.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))


### PR DESCRIPTION
`esm/index.js` does `import * as h from '@kitql/helpers'` and re-exports it (and builds `ff_Log` from it), but the package only listed `@kitql/helpers` under **devDependencies**. Consumers that didn't happen to hoist it hit `Cannot find module '@kitql/helpers'` at runtime (seen in kimbia after a deps bump tightened hoisting).

Moved it to `dependencies`. Changeset included (patch).