### PR TITLE
docs(skill): polish firstly skill (prune, disclose cell layer, FF_/App_ naming)

### DIFF
--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firstly
-description: Firstly-specific patterns on top of Remult - FF_Entity (with built-in changelog), BaseEnum, ff (reactive Svelte layer, many/one), the cell layer (buildCells, FF_Cell, boutique FF_Grid/FF_Group), published modules (mail, cron, changeLog), and the Boutique copy-paste recipes (auth, grid). Use when the user mentions firstly, FF_Entity, BaseEnum, ff/FF_Many/FF_One, buildCells/FF_Cell/FF_Grid/FF_Group, firstly/mail, firstly/cron, or the boutique folder, or when building with `firstly` alongside Remult. Framework-agnostic but SvelteKit is the reference setup.
+description: "firstly - a thin opinionated layer on top of Remult (framework-agnostic, SvelteKit reference). Use when the user mentions firstly, FF_Entity, BaseEnum, the reactive ff layer (ff/FF_Many/FF_One), the cell layer (buildCells/FF_Cell/FF_Grid/GroupFields), firstly modules (mail, cron, changeLog, sqlAdmin), or the boutique copy-paste recipes (auth, grid) - or when building with firstly alongside Remult."
 ---
 
 # Firstly Patterns
@@ -236,54 +236,12 @@ concurrent `+page.server.ts` is unaffected. They differ by where the read goes:
   `backendPrefilter`). BackendMethods keep their own `allowed` gate.
 - Both carry `remult.user` into the scope and pass `event` through untouched.
 
-## Cell layer - metadata-driven grid & form (Svelte 5)
+## Cell layer - metadata-driven grids & forms (Svelte 5)
 
-Grids and forms are built from **field metadata**, in two halves (see
-[firstly.fun /docs/svelte/cell](https://firstly.fun/docs/svelte/cell)):
-
-- **📦 Published** (`firstly/svelte`): `buildCells(meta, cells?)`, `displayCell`, `<FF_Cell>`,
-  `<FF_CellValue>` (renders a cell's value incl. the component escape), `<GroupFields>` (shared form
-  body), `DefaultInput`, the `FF_Config.cell` registry, the `hub` entity config + types. **Plus
-  `<FF_Grid>`** — the batteries-included demo grid (default skin + bundled input, zero setup:
-  `import { FF_Grid } from 'firstly/svelte'`; just mount `<FF_DialogManager>` once).
-- **🛍️ Boutique** (`src/boutique/grid`, copy-own — degit when you want to own the look): `App_Grid`
-  (CRUD grid), `App_Group` (bound record), `Input`. `FF_` = firstly publishes it; `App_` = your app's.
-
-Key rules:
-
-- **Metadata is SSoT.** Per-field UI hints live on the field via `ui` (a firstly augmentation of
-  remult `FieldOptions`): `width`/`marginLeft`/`marginRight` are **% of the row**, plus `align`,
-  `inputType` (override the editor), `order`, and `mobile: {…}` (screens `<= 40rem`). Also
-  `placeholder` and `href: (row)=>string` (renders a `field_link`). Escape hatches on a `CellInput`
-  config: `cellSnippet`, `component` (a lazy `() => Comp` / `() => import('./x.svelte')` thunk) +
-  `props` + `rowToProps`, `sortable` (columns sort by default; per-cell wins), `class`.
-- **Sortable default** is `true`; flip it with `defaultSortable: false` on the `hub` (per-entity) or
-  `FF_Config.cell` (app-wide). Per-cell `sortable` always wins.
-- **Entity hub = SSoT config.** Declare the grid/form config on the entity via the `hub` option
-  (`@FF_Entity<E>('x', { hub: { cells, defaultSortable?, where, orderBy, strategy, pageSize, insert, update, delete } })`).
-  `FF_Grid`/`FF_Group` read it as defaults; every prop overrides. A `hub` whose `cells` reference field
-  keys NEEDS the explicit generic (`@FF_Entity<E>`), else `@Entity` type inference breaks. Keep `hub` a
-  plain object (server-safe) - `component`s must be lazy thunks. `insert`/`update`/`delete` are
-  per-action `ActionConfig` (`{}` on, `false` off); an action's `cells` omitted = inherit the list cells.
-- **Input registry.** Register which component renders each `inputType` once at app root:
-  `<FF_Config cell={{ inputs: { text: Input, number: Input, checkbox: Input } }}>`. firstly ships
-  **no** styled input - the `grid` boutique gives a token-only `Input` to copy.
-- **Read config at init.** Components call `ffConfig()` / `getCellElementConfig()` **at component
-  init only** (Svelte 5 context) - never in a `$derived` or markup. The dialog is portaled to the app
-  root (outside the page `<FF_Config>`), so `FF_Grid` captures `const cfg = ffConfig()` and
-  re-provides `<FF_Config cell={cfg.cell}>` inside the dialog.
-- **The grid** (`FF_Grid` published / `App_Grid` boutique — same code) sits on `ff(E).many` (all three
-  strategies). `cells` = columns (default `hub.cells`); the create/edit forms use
-  `insert.cells`/`update.cells` (default: inherit `cells`). `+ New` / `Edit` disable from
-  `meta.apiInsertAllowed()` / `apiUpdateAllowed(row)`. Cell values render via `FF_CellValue`.
-- **UI naming ≠ security.** Dropping a field from `insert.cells` is UX only. Enforce on the field:
-  `@Fields.boolean({ allowApiUpdate: (t) => !getEntityRef(t).isNew() })` makes it settable on edit but
-  not insert (the API rejects it). The two are complementary - lock on the field, mirror in the UI.
-- **`App_Group`** (boutique) is one bound record (`ff(E).one`): a form when `mode="edit"`, values when
-  `mode="readonly"`; both modes share a height so toggling doesn't shift the page. The grid's dialog
-  and `App_Group` both render the published `GroupFields`, so a field looks identical inline or in a dialog.
-- **Published vs boutique.** `FF_Grid` (batteries demo) + `GroupFields` + `DefaultInput` ARE published;
-  `App_Grid`/`App_Group`/`Input` are the copy-own boutique (`degit .../src/boutique/grid`).
+Grids and forms are built from **field metadata** declared once on the entity and rendered anywhere -
+published `<FF_Grid>` / `buildCells` / `<GroupFields>` plus the copy-own `grid` boutique
+(`App_Grid` / `App_Group`). When building a grid, form, or any `FF_Cell` / `FF_CellValue` /
+`hub` / `ui`-driven UI, read [`cell.md`](cell.md) for the full layer.
 
 ## `dialog` - headless dialogs (Svelte 5)
 

--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -342,6 +342,14 @@ export const Roles = {
 
 Use `Roles.*` in `allowApi*` decorators and assign them to users via the auth boutique's `addRolesToUser` helper or `SUPER_ADMIN_EMAILS`.
 
-## Naming - `FF_` Prefix
+## Naming - `FF_` (firstly's) vs `App_` (yours)
 
-Types and helpers exported by firstly that could collide with user code use the `FF_` prefix: `FF_Entity`, `FF_Role`, `FF_Allow`, `FF_Filter`, `FF_Icon`, `FF_LogToConsole`, `FF_Many` / `FF_One` (reactive handle types). If you see it in an import path, it's firstly's. Factory functions stay camelCase (e.g. `ff`).
+The prefix tells you who owns the code:
+
+- **`FF_` = firstly publishes it** - imported from the package, upgrades with it. Used for exports
+  that could collide with user code: `FF_Entity`, `FF_Role`, `FF_Allow`, `FF_Filter`, `FF_Icon`,
+  `FF_LogToConsole`, `FF_Many` / `FF_One` (reactive handle types), `FF_Grid` / `FF_CellValue`. If you
+  see it in an import path, it's firstly's. Factory functions stay camelCase (e.g. `ff`).
+- **`App_` = your app's** - the copy-own **boutique** version you degit into your codebase and own from
+  then on (e.g. `App_Grid` / `App_Group`, copied from `FF_Grid` / `GroupFields`). Often a boutique
+  recipe is the same code as its `FF_` counterpart, just yours to restyle.

--- a/.claude/skills/firstly/cell.md
+++ b/.claude/skills/firstly/cell.md
@@ -9,7 +9,8 @@ Grids and forms are built from **field metadata** declared once on the entity an
   `<FF_Grid>`** — the batteries-included demo grid (default skin + bundled input, zero setup:
   `import { FF_Grid } from 'firstly/svelte'`; just mount `<FF_DialogManager>` once).
 - **🛍️ Boutique** (`src/boutique/grid`, copy-own — degit when you want to own the look): `App_Grid`
-  (CRUD grid), `App_Group` (bound record), `Input`. `FF_` = firstly publishes it; `App_` = your app's.
+  (CRUD grid), `App_Group` (bound record), `Input`. (`FF_` = firstly's, `App_` = yours - full rule in
+  the SKILL.md Naming section.)
 
 Key rules:
 

--- a/.claude/skills/firstly/cell.md
+++ b/.claude/skills/firstly/cell.md
@@ -1,0 +1,46 @@
+# Cell layer - metadata-driven grids & forms (Svelte 5)
+
+Grids and forms are built from **field metadata** declared once on the entity and rendered anywhere
+(see [firstly.fun /docs/svelte/cell](https://firstly.fun/docs/svelte/cell)). Two halves:
+
+- **📦 Published** (`firstly/svelte`): `buildCells(meta, cells?)`, `displayCell`, `<FF_Cell>`,
+  `<FF_CellValue>` (renders a cell's value incl. the component escape), `<GroupFields>` (shared form
+  body), `DefaultInput`, the `FF_Config.cell` registry, the `hub` entity config + types. **Plus
+  `<FF_Grid>`** — the batteries-included demo grid (default skin + bundled input, zero setup:
+  `import { FF_Grid } from 'firstly/svelte'`; just mount `<FF_DialogManager>` once).
+- **🛍️ Boutique** (`src/boutique/grid`, copy-own — degit when you want to own the look): `App_Grid`
+  (CRUD grid), `App_Group` (bound record), `Input`. `FF_` = firstly publishes it; `App_` = your app's.
+
+Key rules:
+
+- **Metadata is SSoT.** Per-field UI hints live on the field via `ui` (a firstly augmentation of
+  remult `FieldOptions`): `width`/`marginLeft`/`marginRight` are **% of the row**, plus `align`,
+  `inputType` (override the editor), `order`, and `mobile: {…}` (screens `<= 40rem`). Also
+  `placeholder` and `href: (row)=>string` (renders a `field_link`). Escape hatches on a `CellInput`
+  config: `cellSnippet`, `component` (a lazy `() => Comp` / `() => import('./x.svelte')` thunk) +
+  `props` + `rowToProps`, `sortable` (columns sort by default; per-cell wins), `class`.
+- **Sortable default** is `true`; flip it with `defaultSortable: false` on the `hub` (per-entity) or
+  `FF_Config.cell` (app-wide). Per-cell `sortable` always wins.
+- **Entity hub = SSoT config.** Declare the grid/form config on the entity via the `hub` option
+  (`@FF_Entity<E>('x', { hub: { cells, defaultSortable?, where, orderBy, strategy, pageSize, insert, update, delete } })`).
+  `FF_Grid`/`FF_Group` read it as defaults; every prop overrides. A `hub` whose `cells` reference field
+  keys NEEDS the explicit generic (`@FF_Entity<E>`), else `@Entity` type inference breaks. Keep `hub` a
+  plain object (server-safe) - `component`s must be lazy thunks. `insert`/`update`/`delete` are
+  per-action `ActionConfig` (`{}` on, `false` off); an action's `cells` omitted = inherit the list cells.
+- **Input registry.** Register which component renders each `inputType` once at app root:
+  `<FF_Config cell={{ inputs: { text: Input, number: Input, checkbox: Input } }}>`. firstly ships
+  **no** styled input - the `grid` boutique gives a token-only `Input` to copy.
+- **Read config at init.** Components call `ffConfig()` / `getCellElementConfig()` **at component
+  init only** (Svelte 5 context) - never in a `$derived` or markup. The dialog is portaled to the app
+  root (outside the page `<FF_Config>`), so `FF_Grid` captures `const cfg = ffConfig()` and
+  re-provides `<FF_Config cell={cfg.cell}>` inside the dialog.
+- **The grid** (`FF_Grid` published / `App_Grid` boutique — same code) sits on `ff(E).many` (all three
+  strategies). `cells` = columns (default `hub.cells`); the create/edit forms use
+  `insert.cells`/`update.cells` (default: inherit `cells`). `+ New` / `Edit` disable from
+  `meta.apiInsertAllowed()` / `apiUpdateAllowed(row)`. Cell values render via `FF_CellValue`.
+- **UI naming ≠ security.** Dropping a field from `insert.cells` is UX only. Enforce on the field:
+  `@Fields.boolean({ allowApiUpdate: (t) => !getEntityRef(t).isNew() })` makes it settable on edit but
+  not insert (the API rejects it). The two are complementary - lock on the field, mirror in the UI.
+- **`App_Group`** (boutique) is one bound record (`ff(E).one`): a form when `mode="edit"`, values when
+  `mode="readonly"`; both modes share a height so toggling doesn't shift the page. The grid's dialog
+  and `App_Group` both render the published `GroupFields`, so a field looks identical inline or in a dialog.


### PR DESCRIPTION
Polish pass on the `firstly` skill (`.claude/skills/firstly/`), applying the writing-great-skills principles.

## Changes
- **Description** — quoted (defensive against the YAML colon-space bug) and pruned: front-loads the leading word `firstly`, collapses the duplicated identity-list + trigger-list into one list of distinct branches.
- **Progressive disclosure** — moved the long cell layer section into a sibling `cell.md`, reached by a context pointer that fires when building grids/forms/cells. Runs that never touch grids no longer pay its context load.
- **De-duplication** — removed the triple-stated "Published vs boutique"; the intro stays the single source of truth.
- **Naming section** — hoisted the full `FF_` (firstly's) vs `App_` (yours) ownership convention into the top-level Naming section so it's not buried in `cell.md`.

## Notes
- `docs/scripts/sync-skills.mjs` runs clean; frontmatter parses; `index.json` lists `SKILL.md` + `cell.md`.
- Generated `docs/public/.well-known/agent-skills/` output is gitignored (build artifact), so only the two skill files are in the diff.