### PR TITLE
fix(svelte): remultApiServerLoad reads via event.fetch, drop TestApiDataProvider

### DIFF
--- a/.changeset/remult-api-server-load-event-fetch.md
+++ b/.changeset/remult-api-server-load-event-fetch.md
@@ -1,0 +1,5 @@
+---
+'firstly': patch
+---
+
+`remultApiServerLoad` reads through `event.fetch` instead of `TestApiDataProvider`: concurrency-safe on released remult (no process-global static swap), and the API side runs the app's real auth/hooks.

--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -225,15 +225,16 @@ import { remultApiServerLoad } from 'firstly/svelte/server'
 export const load = remultApiServerLoad(async () => ({ tasks: await repo(Task).find() }))
 ```
 
-Both run the body in a scoped `withRemult`, so plain global `repo()` / `ff()` is gated and a
-concurrent `+page.server.ts` is unaffected. They differ by where the read goes:
+Both run the body in a scoped `withRemult` bound to `event.fetch`, so plain global `repo()` /
+`ff()` is gated and a concurrent load keeps its own provider. On the server, SvelteKit dispatches
+same-origin `event.fetch` in-process (no network) with cookies forwarded, so the app's real
+auth/hooks run per read.
 
-- **`remultApiUniversalLoad`** (`firstly/svelte`): a universal load runs on the client too, so it binds
-  to `event.fetch` (gated via `/api`); on CSR/hydration it reuses the inlined SSR response.
-- **`remultApiServerLoad`** (`firstly/svelte/server`, server-only): dispatches in-process through the
-  API pipeline (`TestApiDataProvider`) - no `/api` round-trip. Use it only when a server load should
-  see exactly what the API exposes; otherwise a server load keeps the privileged DB (gate rows with
-  `backendPrefilter`). BackendMethods keep their own `allowed` gate.
+- **`remultApiUniversalLoad`** (`firstly/svelte`): a universal load runs on the client too; on
+  CSR/hydration it reuses the inlined SSR response.
+- **`remultApiServerLoad`** (`firstly/svelte/server`, server-only): use it only when a server load
+  should see exactly what the API exposes; otherwise a server load keeps the privileged DB (gate
+  rows with `backendPrefilter`). BackendMethods keep their own `allowed` gate.
 - Both carry `remult.user` into the scope and pass `event` through untouched.
 
 ## Cell layer - metadata-driven grids & forms (Svelte 5)

--- a/packages/firstly/src/lib/svelte/remultApiLoad.ts
+++ b/packages/firstly/src/lib/svelte/remultApiLoad.ts
@@ -3,21 +3,37 @@ import type { LoadEvent } from '@sveltejs/kit'
 import { isBackend, remult, RestDataProvider, withRemult } from 'remult'
 
 /**
+ * Run `body` in a scoped `withRemult` whose reads go through the API via `fetch`
+ * (`allowApiRead` / `apiPrefilter` apply); a concurrent load keeps its own
+ * provider. `remult.user` is carried in so the body can read it.
+ *
+ * TODO(remult): framework-agnostic (only needs a fetch) - candidate to live in
+ * remult directly.
+ */
+export function withRemultFetch<T>(fetch: typeof globalThis.fetch, body: () => Promise<T>) {
+	const user = remult.user
+	return withRemult(
+		async () => {
+			remult.user = user
+			return body()
+		},
+		{ dataProvider: new RestDataProvider(() => ({ httpClient: fetch })) },
+	)
+}
+
+/**
  * Wrap a SvelteKit UNIVERSAL load (`+page.ts` / `+layout.ts`) so plain global
  * `repo()` / `ff()` reads through the API (so `allowApiRead` / `apiPrefilter`
  * apply), on both SSR and CSR.
  *
- * - SSR: runs the body in a nested `withRemult` bound to `event.fetch` - gated, and
- *   scoped so a concurrent `+page.server.ts` keeps its own provider. SvelteKit
- *   inlines the response. `remult.user` is carried in so the body can read it.
+ * - SSR: runs the body in a scoped `withRemult` bound to `event.fetch` - gated,
+ *   and a concurrent `+page.server.ts` keeps its own provider. SvelteKit inlines
+ *   the response.
  * - CSR / hydration: points the client `remult` at this page's `event.fetch` so the
  *   inlined SSR response is reused, then runs the body.
  *
  * (A universal load runs on the client too, so it must use `event.fetch`. For a
  * server-only load see `remultApiServerLoad` from `firstly/svelte/server`.)
- *
- * TODO(remult): the SSR branch is framework-agnostic (only needs `event.fetch`) -
- * candidate to live in remult (e.g. `withRemultFetch(fetch, body)`).
  */
 export function remultApiUniversalLoad<T>(body: (event: LoadEvent) => Promise<T>) {
 	return (event: LoadEvent): Promise<T> => {
@@ -25,13 +41,6 @@ export function remultApiUniversalLoad<T>(body: (event: LoadEvent) => Promise<T>
 			remult.apiClient.httpClient = event.fetch
 			return body(event)
 		}
-		const user = remult.user
-		return withRemult(
-			async () => {
-				remult.user = user
-				return body(event)
-			},
-			{ dataProvider: new RestDataProvider(() => ({ httpClient: event.fetch })) },
-		)
+		return withRemultFetch(event.fetch, () => body(event))
 	}
 }

--- a/packages/firstly/src/lib/svelte/server/index.ts
+++ b/packages/firstly/src/lib/svelte/server/index.ts
@@ -1,35 +1,18 @@
 import type { ServerLoadEvent } from '@sveltejs/kit'
 
-import { remult, withRemult } from 'remult'
-import { TestApiDataProvider } from 'remult/server'
-
-// SERVER-ONLY (imports `remult/server`). Never import from client-reachable code.
-
-// Lazily wrap the app's dataProvider once. TestApiDataProvider dispatches repo()
-// through the API pipeline in-process (so allowApiRead / apiPrefilter apply) and
-// carries the current user - no event.fetch, no `/api` round-trip.
-let apiDataProvider: ReturnType<typeof TestApiDataProvider> | undefined
+import { withRemultFetch } from '../remultApiLoad.js'
 
 /**
  * Wrap a SvelteKit SERVER load (`+page.server.ts`) so plain global `repo()` reads
- * apply the API gate (as the current user) instead of the privileged in-process
- * provider. Use it only when a server load should see exactly what the API exposes;
- * otherwise a server load keeps the DB provider (gate rows with `backendPrefilter`).
- * Gates direct `repo()` reads; BackendMethods keep their own `allowed` gate.
+ * apply the API gate (as the current user) instead of the privileged DB provider.
  *
- * TODO(remult): framework-agnostic (event passed through; provider read from
- * `remult`) - candidate to live in remult directly.
+ * Reads go through `event.fetch`: SvelteKit dispatches same-origin server fetch
+ * in-process (no network) and forwards cookies, so the app's real auth/hooks run
+ * for each read. Use it only when a server load should see exactly what the API
+ * exposes; otherwise a server load keeps the DB provider (gate rows with
+ * `backendPrefilter`). Gates direct `repo()` reads; BackendMethods keep their own
+ * `allowed` gate.
  */
 export function remultApiServerLoad<T>(body: (event: ServerLoadEvent) => Promise<T>) {
-	return (event: ServerLoadEvent): Promise<T> => {
-		apiDataProvider ??= TestApiDataProvider({ dataProvider: remult.dataProvider })
-		const user = remult.user
-		return withRemult(
-			async () => {
-				remult.user = user
-				return body(event)
-			},
-			{ dataProvider: apiDataProvider },
-		)
-	}
+	return (event: ServerLoadEvent): Promise<T> => withRemultFetch(event.fetch, () => body(event))
 }


### PR DESCRIPTION
- Released remult's `TestApiDataProvider` swaps process-global remult statics on every call; a concurrent request's `withRemult` during that window loses its context (cross-request bleed / "outside of a valid request cycle").
- `ServerLoadEvent.fetch` gives the same in-process dispatch (SvelteKit resolves same-origin fetch internally, cookies forwarded), so reads go through the real API with the app's actual auth/hooks - same mechanism `remultApiUniversalLoad` already uses on SSR, now shared via `withRemultFetch`.
- No remult version requirement change; e2e for both routes unchanged and passing.