### PR TITLE
feat(cron): quieter logs by default + failed status

### DIFF
--- a/.changeset/cron-quieter-logs.md
+++ b/.changeset/cron-quieter-logs.md
@@ -2,4 +2,4 @@
 "firstly": minor
 ---
 
-cron: quieter logs by default - one `done in Xms` line per tick; `starting` and `result` lines are now opt-in via `logs`, and `logs.setup` can silence the registration line. If `onTick` throws, the run is now stored as `failed` (error in `result`), always logged, and no longer leaks the concurrency slot.
+cron: quieter logs by default - a tick only logs `done in Xms` when it took at least `logs.ended` ms (default 100; `true` = always, `false` = never). `starting` and `result` lines are opt-in, `logs.setup` can silence the registration line. If `onTick` throws, the run is now stored as `failed` (error in `result`), always logged, and no longer leaks the concurrency slot.

--- a/.changeset/cron-quieter-logs.md
+++ b/.changeset/cron-quieter-logs.md
@@ -1,0 +1,5 @@
+---
+"firstly": minor
+---
+
+cron: quieter logs by default - one `done in Xms` line per tick; `starting` and `result` lines are now opt-in via `logs`, and `logs.setup` can silence the registration line. If `onTick` throws, the run is now stored as `failed` (error in `result`), always logged, and no longer leaks the concurrency slot.

--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -85,6 +85,10 @@ export const api = remultApi({
 
 Available today: `mail`, `cron`, `changeLog`, `sqlAdmin`. See [firstly.fun](https://firstly.fun) for the full list.
 
+### `cron` - logs & failures
+
+Each tick logs one `done in Xms` line; tune per job with `logs: { setup?, starting?, result?, ended? }` (`starting`/`result` are opt-in, failures and concurrency skips always log). Full run history (results, errors, skips) lives in the `_ff_crons` entity ("FF Crons" in Admin UI, gated by `Roles_Cron.Cron_Admin`). A throwing `onTick` is stored as `failed` and never stops the schedule.
+
 ### `sqlAdmin` - drop-in raw SQL page
 
 A backend `BackendMethod` + a `<SqlAdmin />` Svelte component, both shipped from one module. Gated by `Roles_SqlAdmin.SqlAdmin_Admin` (or the global `FF_Role.FF_Role_Admin`).

--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -87,7 +87,7 @@ Available today: `mail`, `cron`, `changeLog`, `sqlAdmin`. See [firstly.fun](http
 
 ### `cron` - logs & failures
 
-Each tick logs one `done in Xms` line; tune per job with `logs: { setup?, starting?, result?, ended? }` (`starting`/`result` are opt-in, failures and concurrency skips always log). Full run history (results, errors, skips) lives in the `_ff_crons` entity ("FF Crons" in Admin UI, gated by `Roles_Cron.Cron_Admin`). A throwing `onTick` is stored as `failed` and never stops the schedule.
+A tick logs one `done in Xms` line only when it took at least `logs.ended` ms (default 100; `true` = always, `false` = never); `starting`/`result` are opt-in, failures and concurrency skips always log. Full run history (results, errors, skips) lives in the `_ff_crons` entity ("FF Crons" in Admin UI, gated by `Roles_Cron.Cron_Admin`). A throwing `onTick` is stored as `failed` and never stops the schedule.
 
 ### `sqlAdmin` - drop-in raw SQL page
 

--- a/docs/src/content/docs/docs/modules/cron.mdx
+++ b/docs/src/content/docs/docs/modules/cron.mdx
@@ -52,7 +52,7 @@ export const api = remultApi({
 By default, a tick only logs when it took at least 100ms:
 
 ```bash
- cron  ✔ [first_cron] done in 230ms
+cron ✔ [first_cron] done in 230ms
 ```
 
 Fast ticks stay silent. Failures and concurrency skips are always logged. The rest is configurable

--- a/docs/src/content/docs/docs/modules/cron.mdx
+++ b/docs/src/content/docs/docs/modules/cron.mdx
@@ -49,20 +49,21 @@ export const api = remultApi({
 
 ## Logs
 
-By default, each tick logs a single line:
+By default, a tick only logs when it took at least 100ms:
 
 ```bash
- cron  ✔ [first_cron] done in 12ms
+ cron  ✔ [first_cron] done in 230ms
 ```
 
-Failures and concurrency skips are always logged. The rest is configurable per job:
+Fast ticks stay silent. Failures and concurrency skips are always logged. The rest is configurable
+per job:
 
 ```ts
 logs: {
   setup: true, // at registration: "setup done (running, next at ...)"
-  ended: true, // after each tick: "done in 12ms"
+  ended: 100, // min duration (ms) to log "done in Xms". true = always, false = never
   starting: false, // before each tick: "starting..."
-  result: false, // attach onTick's return value to the "done" line
+  result: false, // attach onTick's return value to the "done" line (when it logs)
 }
 ```
 

--- a/docs/src/content/docs/docs/modules/cron.mdx
+++ b/docs/src/content/docs/docs/modules/cron.mdx
@@ -40,9 +40,36 @@ export const api = remultApi({
 
         // OPTIONAL
         concurrent: 1, // Default is 1, if we are at the limit, the job will be skipped.
-        logs: {}, // to log more or less stuff, I let you look the ts definition.
+        logs: {}, // to log more or less stuff, see Logs below.
       }
     ])
   ]
 })
 ```
+
+## Logs
+
+By default, each tick logs a single line:
+
+```bash
+ cron  ✔ [first_cron] done in 12ms
+```
+
+Failures and concurrency skips are always logged. The rest is configurable per job:
+
+```ts
+logs: {
+  setup: true, // at registration: "setup done (running, next at ...)"
+  ended: true, // after each tick: "done in 12ms"
+  starting: false, // before each tick: "starting..."
+  result: false, // attach onTick's return value to the "done" line
+}
+```
+
+The full run history (results, errors, skips) is always stored in the `FF Crons` entity, so quiet
+logs don't lose anything.
+
+## Errors
+
+If `onTick` throws, the run is stored with the status `failed` (the error message lands in
+`result`) and an error line is logged. The job keeps running on schedule.

--- a/packages/firstly/src/lib/cron/Cron.ts
+++ b/packages/firstly/src/lib/cron/Cron.ts
@@ -2,7 +2,7 @@ import { Entity, Fields } from 'remult'
 
 import { Roles_Cron } from './Roles_Cron'
 
-const statuses = ['starting', 'ended', 'skipped'] as const
+const statuses = ['starting', 'ended', 'skipped', 'failed'] as const
 type StatusType = (typeof statuses)[number]
 
 @Entity<Cron>('_ff_crons', {

--- a/packages/firstly/src/lib/cron/server/index.spec.ts
+++ b/packages/firstly/src/lib/cron/server/index.spec.ts
@@ -25,7 +25,7 @@ describe('cron', () => {
 		errorSpy = vi.spyOn(log, 'error').mockImplementation(() => [])
 	})
 
-	it('stores the run and logs a single done line by default', async () => {
+	it('stores the run and stays silent for a fast tick by default', async () => {
 		const job = await register({
 			topic: 'c_default',
 			cronTime: '0 3 * * *',
@@ -43,19 +43,31 @@ describe('cron', () => {
 		expect(row.result).toEqual({ ok: 1 })
 		expect(row.endedAt).not.toBeNull()
 
-		await vi.waitFor(() => expect(successSpy).toHaveBeenCalledTimes(2))
-		const doneCall = successSpy.mock.calls[1]
-		expect(doneCall[0]).toContain('done in')
-		// no starting/result lines by default
-		expect(doneCall).toHaveLength(1)
+		// under the 100ms default, no done line (and no starting/result lines)
+		expect(successSpy).toHaveBeenCalledOnce()
 		expect(infoSpy).not.toHaveBeenCalled()
 	})
 
-	it('logs starting and result when opted in', async () => {
+	it('logs the done line when the tick is slower than the threshold', async () => {
+		const job = await register({
+			topic: 'c_slow',
+			cronTime: '0 3 * * *',
+			logs: { ended: 50 },
+			onTick: async () => {
+				await new Promise((r) => setTimeout(r, 60))
+				return { ok: 1 }
+			},
+		})
+		await job.fireOnTick()
+		await vi.waitFor(() => expect(successSpy).toHaveBeenCalledTimes(2))
+		expect(successSpy.mock.calls[1][0]).toContain('done in')
+	})
+
+	it('logs starting and result when opted in (ended: true = always)', async () => {
 		const job = await register({
 			topic: 'c_verbose',
 			cronTime: '0 3 * * *',
-			logs: { starting: true, result: true },
+			logs: { starting: true, result: true, ended: true },
 			onTick: () => ({ ok: 1 }),
 		})
 		await job.fireOnTick()

--- a/packages/firstly/src/lib/cron/server/index.spec.ts
+++ b/packages/firstly/src/lib/cron/server/index.spec.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { InMemoryDataProvider, remult, repo, type Remult } from 'remult'
+
+import { log } from '..'
+import { Cron } from '../Cron'
+import { cron, jobs, type CronJobParams } from './index'
+
+const register = async (params: CronJobParams) => {
+	const m = cron([params])
+	await m.initApi?.(remult as Remult)
+	return jobs[params.topic].job!
+}
+
+describe('cron', () => {
+	let successSpy: ReturnType<typeof vi.spyOn>
+	let infoSpy: ReturnType<typeof vi.spyOn>
+	let errorSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		remult.dataProvider = new InMemoryDataProvider()
+		vi.restoreAllMocks()
+		successSpy = vi.spyOn(log, 'success').mockImplementation(() => [])
+		infoSpy = vi.spyOn(log, 'info').mockImplementation(() => [])
+		errorSpy = vi.spyOn(log, 'error').mockImplementation(() => [])
+	})
+
+	it('stores the run and logs a single done line by default', async () => {
+		const job = await register({
+			topic: 'c_default',
+			cronTime: '0 3 * * *',
+			onTick: () => ({ ok: 1 }),
+		})
+		expect(successSpy).toHaveBeenCalledOnce()
+		expect(successSpy.mock.calls[0][0]).toContain('setup done')
+
+		await job.fireOnTick()
+		await vi.waitFor(async () => {
+			expect(await repo(Cron).count({ topic: 'c_default', status: 'ended' })).toBe(1)
+		})
+
+		const row = (await repo(Cron).findFirst({ topic: 'c_default' }))!
+		expect(row.result).toEqual({ ok: 1 })
+		expect(row.endedAt).not.toBeNull()
+
+		await vi.waitFor(() => expect(successSpy).toHaveBeenCalledTimes(2))
+		const doneCall = successSpy.mock.calls[1]
+		expect(doneCall[0]).toContain('done in')
+		// no starting/result lines by default
+		expect(doneCall).toHaveLength(1)
+		expect(infoSpy).not.toHaveBeenCalled()
+	})
+
+	it('logs starting and result when opted in', async () => {
+		const job = await register({
+			topic: 'c_verbose',
+			cronTime: '0 3 * * *',
+			logs: { starting: true, result: true },
+			onTick: () => ({ ok: 1 }),
+		})
+		await job.fireOnTick()
+		await vi.waitFor(() => expect(successSpy).toHaveBeenCalledTimes(2))
+
+		expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('starting...'))
+		const doneCall = successSpy.mock.calls[1]
+		expect(doneCall[0]).toContain('done in')
+		expect(doneCall[1]).toEqual({ ok: 1 })
+	})
+
+	it('is fully silent with setup & ended off', async () => {
+		const job = await register({
+			topic: 'c_silent',
+			cronTime: '0 3 * * *',
+			logs: { setup: false, ended: false },
+			onTick: () => ({ ok: 1 }),
+		})
+		await job.fireOnTick()
+		await vi.waitFor(async () => {
+			expect(await repo(Cron).count({ topic: 'c_silent', status: 'ended' })).toBe(1)
+		})
+		expect(successSpy).not.toHaveBeenCalled()
+		expect(infoSpy).not.toHaveBeenCalled()
+	})
+
+	it('marks failed runs, logs the error, and frees the concurrency slot', async () => {
+		let boom = true
+		const job = await register({
+			topic: 'c_fail',
+			cronTime: '0 3 * * *',
+			onTick: () => {
+				if (boom) throw new Error('boom')
+				return { ok: 1 }
+			},
+		})
+
+		await job.fireOnTick()
+		await vi.waitFor(async () => {
+			expect(await repo(Cron).count({ topic: 'c_fail', status: 'failed' })).toBe(1)
+		})
+		const failed = (await repo(Cron).findFirst({ topic: 'c_fail', status: 'failed' }))!
+		expect(failed.result).toEqual({ error: 'boom' })
+		expect(failed.endedAt).not.toBeNull()
+		expect(errorSpy).toHaveBeenCalledOnce()
+		expect(errorSpy.mock.calls[0][0]).toContain('failed after')
+
+		// the slot was freed, next tick runs instead of being skipped
+		boom = false
+		await job.fireOnTick()
+		await vi.waitFor(async () => {
+			expect(await repo(Cron).count({ topic: 'c_fail', status: 'ended' })).toBe(1)
+		})
+	})
+
+	it('skips (and always logs) when the concurrent limit is reached', async () => {
+		let release!: () => void
+		const gate = new Promise<void>((r) => (release = r))
+		const job = await register({
+			topic: 'c_skip',
+			cronTime: '0 3 * * *',
+			onTick: async () => {
+				await gate
+				return { ok: 1 }
+			},
+		})
+
+		await job.fireOnTick()
+		await job.fireOnTick()
+		await vi.waitFor(async () => {
+			expect(await repo(Cron).count({ topic: 'c_skip', status: 'skipped' })).toBe(1)
+		})
+		expect(infoSpy).toHaveBeenCalledWith(
+			expect.stringContaining('skipped because of concurrent limit'),
+		)
+
+		release()
+		await vi.waitFor(async () => {
+			expect(await repo(Cron).count({ topic: 'c_skip', status: 'ended' })).toBe(1)
+		})
+	})
+})

--- a/packages/firstly/src/lib/cron/server/index.ts
+++ b/packages/firstly/src/lib/cron/server/index.ts
@@ -56,11 +56,12 @@ export type CronJobParams = {
 	topic: string
 	concurrent?: number
 	/**
-	 * Defaults: one `done in Xms` line per tick + a `setup done` line at registration.
+	 * Defaults: a tick logs `done in Xms` only when it took at least `ended` ms
+	 * (default 100, `true` = always, `false` = never) + a `setup done` line at registration.
 	 * `starting` & `result` are opt-in (full history incl. results is stored in `_ff_crons`).
 	 * Failures and concurrency skips are always logged.
 	 */
-	logs?: { setup?: boolean; starting?: boolean; result?: boolean; ended?: boolean }
+	logs?: { setup?: boolean; starting?: boolean; result?: boolean; ended?: boolean | number }
 	start?: boolean
 	runOnInit?: boolean
 	timeZone?: string
@@ -68,10 +69,9 @@ export type CronJobParams = {
 	onComplete?: () => void
 }
 
-const duration = (startedAt: number) => {
-	const ms = Date.now() - startedAt
-	return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`
-}
+const DEFAULT_ENDED_MIN_MS = 100
+
+const fmtDuration = (ms: number) => (ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`)
 
 /**
  * usage:
@@ -110,6 +110,12 @@ export const cron: (jobsInfos: CronJobParams[]) => Module<unknown> = (jobsInfos)
 
 			const concurrentToUse = concurrent ?? 1
 			const prefix = magenta(`[${topic}]`)
+			const endedMinMs =
+				logs?.ended === false
+					? Infinity
+					: logs?.ended === true
+						? 0
+						: (logs?.ended ?? DEFAULT_ENDED_MIN_MS)
 
 			// Create a wrapper that converts the return type to void for CronJob
 			const wrappedOnTick = async (): Promise<void> => {
@@ -134,8 +140,9 @@ export const cron: (jobsInfos: CronJobParams[]) => Module<unknown> = (jobsInfos)
 					rCron.status = 'ended'
 					await repo(Cron).save(rCron)
 
-					if (logs?.ended !== false) {
-						const msg = `${prefix} done in ${duration(startedAt)}`
+					const ms = Date.now() - startedAt
+					if (ms >= endedMinMs) {
+						const msg = `${prefix} done in ${fmtDuration(ms)}`
 						if (logs?.result) {
 							log.success(msg, res)
 						} else {
@@ -147,7 +154,7 @@ export const cron: (jobsInfos: CronJobParams[]) => Module<unknown> = (jobsInfos)
 					rCron.endedAt = new Date()
 					rCron.status = 'failed'
 					await repo(Cron).save(rCron)
-					log.error(`${prefix} failed after ${duration(startedAt)}`, error)
+					log.error(`${prefix} failed after ${fmtDuration(Date.now() - startedAt)}`, error)
 				} finally {
 					jobs[topic].concurrentInProgress--
 				}

--- a/packages/firstly/src/lib/cron/server/index.ts
+++ b/packages/firstly/src/lib/cron/server/index.ts
@@ -55,12 +55,22 @@ export type CronJobParams = {
 	onTick: CronOnTick
 	topic: string
 	concurrent?: number
-	logs?: { starting?: boolean; ended?: boolean }
+	/**
+	 * Defaults: one `done in Xms` line per tick + a `setup done` line at registration.
+	 * `starting` & `result` are opt-in (full history incl. results is stored in `_ff_crons`).
+	 * Failures and concurrency skips are always logged.
+	 */
+	logs?: { setup?: boolean; starting?: boolean; result?: boolean; ended?: boolean }
 	start?: boolean
 	runOnInit?: boolean
 	timeZone?: string
 	utcOffset?: string | number
 	onComplete?: () => void
+}
+
+const duration = (startedAt: number) => {
+	const ms = Date.now() - startedAt
+	return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`
 }
 
 /**
@@ -94,64 +104,52 @@ export const cron: (jobsInfos: CronJobParams[]) => Module<unknown> = (jobsInfos)
 		entities: [Cron],
 	})
 
-	const logJobs = (
-		topic: string,
-		job: CronJob<null, unknown>,
-		message: string,
-		with_metadata = true,
-		isSuccess = true,
-	) => {
-		const l = []
-		l.push(magenta(`[${topic}]`))
-		l.push(message)
-		if (with_metadata) {
-			// If the job is "stopped", there will still be a next date, but it will not fire it. The job has to start.
-			l.push(
-				`(${job.isActive ? green('running') : red('stopped')}, next at ${yellow(job.nextDate().toISO()!)})`,
-			)
-		}
-
-		if (isSuccess) {
-			log.success(l.join(' '))
-		} else {
-			log.info(l.join(' '))
-		}
-	}
-
 	m.initApi = async () => {
 		jobsInfos.forEach((infos) => {
 			const { topic, runOnInit, logs, concurrent, onTick: originalOnTick, ...params } = infos
 
 			const concurrentToUse = concurrent ?? 1
+			const prefix = magenta(`[${topic}]`)
 
 			// Create a wrapper that converts the return type to void for CronJob
 			const wrappedOnTick = async (): Promise<void> => {
-				if (jobs[topic].concurrentInProgress < concurrentToUse) {
-					jobs[topic].concurrentInProgress = jobs[topic].concurrentInProgress + 1
-					const rCron = await repo(Cron).insert({ topic })
-					if (logs?.starting === undefined || logs?.starting === true) {
-						logJobs(topic, job, 'starting...', false, false)
-					}
+				if (jobs[topic].concurrentInProgress >= concurrentToUse) {
+					await repo(Cron).insert({ topic, status: 'skipped' })
+					log.info(
+						`${prefix} skipped because of concurrent limit (${yellow(concurrentToUse.toString())})`,
+					)
+					return
+				}
+
+				jobs[topic].concurrentInProgress++
+				const startedAt = Date.now()
+				const rCron = await repo(Cron).insert({ topic })
+				if (logs?.starting) {
+					log.info(`${prefix} starting...`)
+				}
+				try {
 					const res = await originalOnTick()
-					log.info(`[${topic}] result:`, res)
 					rCron.result = res
 					rCron.endedAt = new Date()
 					rCron.status = 'ended'
 					await repo(Cron).save(rCron)
 
-					if (logs?.ended === undefined || logs?.ended === true) {
-						logJobs(topic, job, 'done')
+					if (logs?.ended !== false) {
+						const msg = `${prefix} done in ${duration(startedAt)}`
+						if (logs?.result) {
+							log.success(msg, res)
+						} else {
+							log.success(msg)
+						}
 					}
-					jobs[topic].concurrentInProgress = jobs[topic].concurrentInProgress - 1
-				} else {
-					await repo(Cron).insert({ topic, status: 'skipped' })
-					logJobs(
-						topic,
-						job,
-						`skipped because of concurrent limit (${yellow(concurrentToUse.toString())})`,
-						false,
-						false,
-					)
+				} catch (error) {
+					rCron.result = { error: error instanceof Error ? error.message : String(error) }
+					rCron.endedAt = new Date()
+					rCron.status = 'failed'
+					await repo(Cron).save(rCron)
+					log.error(`${prefix} failed after ${duration(startedAt)}`, error)
+				} finally {
+					jobs[topic].concurrentInProgress--
 				}
 			}
 
@@ -163,7 +161,12 @@ export const cron: (jobsInfos: CronJobParams[]) => Module<unknown> = (jobsInfos)
 
 			jobs[topic] = { job, concurrentInProgress: 0 }
 
-			logJobs(topic, job, 'setup done')
+			if (logs?.setup !== false) {
+				// A stopped job still reports a next date, it just won't fire it.
+				log.success(
+					`${prefix} setup done (${job.isActive ? green('running') : red('stopped')}, next at ${yellow(job.nextDate().toISO()!)})`,
+				)
+			}
 
 			// If not it will be done too early
 			if (runOnInit) {


### PR DESCRIPTION
- A tick now only logs `done in Xms` when it took at least `logs.ended` ms (default 100; `true` = always, `false` = never). `starting`/`result` lines are opt-in, `logs.setup` can silence the registration line. Failures and concurrency skips always log.
- A throwing `onTick` no longer leaks the concurrency slot or leaves the row stuck on `starting`: the run is stored as `failed` with the error, and the schedule keeps going.
- Docs + skill updated, cron module now has unit tests.