### PR TITLE
feat: withShortTermCache + tab-shared SSE subscription client

### DIFF
--- a/.changeset/client-stack-cache-sse.md
+++ b/.changeset/client-stack-cache-sse.md
@@ -1,0 +1,5 @@
+---
+'firstly': minor
+---
+
+feat: `withShortTermCache` http middleware (dedupes identical read requests within a TTL) and `stackSubscriptionClient` + `withTabSharing` (one shared SSE connection across tabs via `navigator.locks`, with liveQuery resync on leader handoff and reconnect)

--- a/packages/firstly/src/lib/core/httpClientStack.spec.ts
+++ b/packages/firstly/src/lib/core/httpClientStack.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { stackHttpClient, withHeader } from './httpClientStack'
+import { stackHttpClient, withHeader, withShortTermCache } from './httpClientStack'
 
 afterEach(() => vi.unstubAllGlobals())
 
@@ -32,5 +32,83 @@ describe('stackHttpClient', () => {
 
 		await stackHttpClient(withHeader('x-token', () => null))('/x')
 		expect(received?.has('x-token')).toBe(false)
+	})
+})
+
+describe('withShortTermCache', () => {
+	it('dedupes identical GETs within the TTL and hands out clones', async () => {
+		let calls = 0
+		vi.stubGlobal('fetch', () => {
+			calls++
+			return Promise.resolve(new Response('ok'))
+		})
+
+		const client = stackHttpClient(withShortTermCache({ ttlMs: 1000 }))
+		const [a, b] = await Promise.all([client('/api/tasks'), client('/api/tasks')])
+
+		expect(calls).toBe(1)
+		expect(await a.text()).toBe('ok')
+		expect(await b.text()).toBe('ok') // clones: both bodies readable
+	})
+
+	it('expires after the TTL', async () => {
+		vi.useFakeTimers()
+		let calls = 0
+		vi.stubGlobal('fetch', () => {
+			calls++
+			return Promise.resolve(new Response('ok'))
+		})
+
+		const client = stackHttpClient(withShortTermCache({ ttlMs: 1000 }))
+		await client('/api/tasks')
+		vi.advanceTimersByTime(1001)
+		await client('/api/tasks')
+
+		expect(calls).toBe(2)
+		vi.useRealTimers()
+	})
+
+	it('caches remult read-only POSTs but not writes', async () => {
+		let calls = 0
+		vi.stubGlobal('fetch', () => {
+			calls++
+			return Promise.resolve(new Response('ok'))
+		})
+
+		const client = stackHttpClient(withShortTermCache())
+		await client('/api/tasks?__action=get', { method: 'POST', body: '{}' })
+		await client('/api/tasks?__action=get', { method: 'POST', body: '{}' })
+		expect(calls).toBe(1)
+
+		await client('/api/tasks', { method: 'POST', body: '{}' })
+		await client('/api/tasks', { method: 'POST', body: '{}' })
+		expect(calls).toBe(3)
+	})
+
+	it('keys by body so different queries do not collide', async () => {
+		const seen: string[] = []
+		vi.stubGlobal('fetch', (_i: RequestInfo | URL, init?: RequestInit) => {
+			seen.push(String(init?.body))
+			return Promise.resolve(new Response('ok'))
+		})
+
+		const client = stackHttpClient(withShortTermCache())
+		await client('/api/tasks?__action=get', { method: 'POST', body: '{"a":1}' })
+		await client('/api/tasks?__action=get', { method: 'POST', body: '{"a":2}' })
+		expect(seen).toHaveLength(2)
+	})
+
+	it('evicts failed requests so the next call retries', async () => {
+		let calls = 0
+		vi.stubGlobal('fetch', () => {
+			calls++
+			return calls === 1 ? Promise.reject(new Error('boom')) : Promise.resolve(new Response('ok'))
+		})
+
+		const client = stackHttpClient(withShortTermCache())
+		await expect(client('/api/tasks')).rejects.toThrow('boom')
+		const res = await client('/api/tasks')
+		expect(await res.text()).toBe('ok')
+		expect(calls).toBe(2)
 	})
 })

--- a/packages/firstly/src/lib/core/httpClientStack.ts
+++ b/packages/firstly/src/lib/core/httpClientStack.ts
@@ -22,6 +22,88 @@ export function stackHttpClient(...middlewares: HttpClientMiddleware[]): HttpCli
 	)
 }
 
+export type ShortTermCacheOptions = {
+	/** How long a response is served from cache (default 2000ms). */
+	ttlMs?: number
+	/**
+	 * Decide per request if it is cacheable. Default: GET requests, plus remult's
+	 * read-only POSTs (`__action=get` / `__action=groupBy`, used when a filter is too
+	 * long for a query string).
+	 */
+	shouldCache?: (
+		input: RequestInfo | URL,
+		init: RequestInit | undefined,
+		cacheKey: string,
+	) => boolean
+}
+
+const defaultShouldCache: NonNullable<ShortTermCacheOptions['shouldCache']> = (
+	_input,
+	init,
+	key,
+) => {
+	const method = init?.method?.toUpperCase() ?? 'GET'
+	if (method === 'GET') return true
+	if (method === 'POST') return key.includes('__action=get') || key.includes('__action=groupBy')
+	return false
+}
+
+/**
+ * Middleware that dedupes identical read requests within a short TTL - a tiny
+ * client-side cache. Two components mounting and issuing the same query result in
+ * ONE network call; each caller gets its own `Response` clone. Failed requests are
+ * evicted immediately so the next call retries.
+ *
+ * ```ts
+ * remult.apiClient.httpClient = stackHttpClient(withShortTermCache({ ttlMs: 2000 }))
+ * ```
+ */
+export function withShortTermCache(opts: ShortTermCacheOptions = {}): HttpClientMiddleware {
+	const ttlMs = opts.ttlMs ?? 2000
+	const shouldCache = opts.shouldCache ?? defaultShouldCache
+	const cache = new Map<string, { promise: Promise<Response>; timestamp: number }>()
+
+	return (next) => async (input, init) => {
+		let cacheKey = input.toString()
+		if (init?.body) {
+			const body = init.body
+			const bodyStr =
+				typeof body === 'string'
+					? body
+					: body instanceof URLSearchParams
+						? body.toString()
+						: JSON.stringify(body)
+			cacheKey = `${cacheKey}:${bodyStr}`
+		}
+
+		if (!shouldCache(input, init, cacheKey)) {
+			return next(input, init)
+		}
+
+		const now = Date.now()
+		const cached = cache.get(cacheKey)
+		if (cached) {
+			if (now - cached.timestamp < ttlMs) {
+				const response = await cached.promise
+				return response.clone()
+			}
+			cache.delete(cacheKey)
+		}
+
+		// Keep a pristine copy in cache; every consumer (incl. this one) reads a clone.
+		const promise = next(input, init).then((r) => r.clone())
+		cache.set(cacheKey, { promise, timestamp: now })
+
+		try {
+			const response = await promise
+			return response.clone()
+		} catch (e) {
+			cache.delete(cacheKey)
+			throw e
+		}
+	}
+}
+
 /** Middleware that sets a request header from `getValue()` when it returns a value. */
 export function withHeader(
 	name: string,

--- a/packages/firstly/src/lib/core/subscriptionClientStack.spec.ts
+++ b/packages/firstly/src/lib/core/subscriptionClientStack.spec.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SubscriptionClient, SubscriptionClientConnection } from 'remult'
+
+import { stackSubscriptionClient, withTabSharing } from './subscriptionClientStack'
+
+// ---- fakes: BroadcastChannel + navigator.locks (exclusive queue) ----
+
+class FakeBroadcastChannel {
+	static registry = new Map<string, Set<FakeBroadcastChannel>>()
+	onmessage: ((e: { data: unknown }) => void) | null = null
+	#closed = false
+	constructor(public name: string) {
+		let peers = FakeBroadcastChannel.registry.get(name)
+		if (!peers) FakeBroadcastChannel.registry.set(name, (peers = new Set()))
+		peers.add(this)
+	}
+	postMessage(data: unknown) {
+		for (const peer of FakeBroadcastChannel.registry.get(this.name) ?? []) {
+			if (peer === this || peer.#closed) continue
+			queueMicrotask(() => peer.onmessage?.({ data }))
+		}
+	}
+	close() {
+		this.#closed = true
+		FakeBroadcastChannel.registry.get(this.name)?.delete(this)
+	}
+}
+
+function fakeLocks() {
+	const queues = new Map<string, Promise<unknown>>()
+	return {
+		request(name: string, _opts: unknown, cb: () => Promise<unknown>) {
+			const tail = queues.get(name) ?? Promise.resolve()
+			const p = tail.then(() => cb())
+			queues.set(
+				name,
+				p.catch(() => {}),
+			)
+			return p
+		},
+	}
+}
+
+// Drain microtasks so bus messages and lock handoffs settle.
+const flush = async (n = 20) => {
+	for (let i = 0; i < n; i++) await Promise.resolve()
+}
+
+type FakeReal = {
+	client: SubscriptionClient
+	opened: number
+	subscribed: string[]
+	unsubscribed: string[]
+	fireReconnect: () => void
+	publish: (channel: string, data: unknown) => void
+}
+
+function fakeRealClient(): FakeReal {
+	const handlers = new Map<string, (data: unknown) => void>()
+	let onReconnectRef: VoidFunction = () => {}
+	const state: FakeReal = {
+		opened: 0,
+		subscribed: [],
+		unsubscribed: [],
+		fireReconnect: () => onReconnectRef(),
+		publish: (channel, data) => handlers.get(channel)?.(data),
+		client: {
+			async openConnection(onReconnect) {
+				state.opened++
+				onReconnectRef = onReconnect
+				const connection: SubscriptionClientConnection = {
+					close() {},
+					async subscribe(channel, handler) {
+						state.subscribed.push(channel)
+						handlers.set(channel, handler)
+						return () => {
+							state.unsubscribed.push(channel)
+							handlers.delete(channel)
+						}
+					},
+				}
+				return connection
+			},
+		},
+	}
+	return state
+}
+
+beforeEach(() => {
+	FakeBroadcastChannel.registry.clear()
+	vi.stubGlobal('window', {})
+	vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel)
+	vi.stubGlobal('navigator', { locks: fakeLocks() })
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('stackSubscriptionClient', () => {
+	it('with a middleware, composes around the base client', async () => {
+		const real = fakeRealClient()
+		const client = stackSubscriptionClient((_next) => real.client)
+		await client.openConnection(() => {})
+		expect(real.opened).toBe(1)
+	})
+})
+
+describe('withTabSharing', () => {
+	it('falls back to the bare client when BroadcastChannel is unavailable', () => {
+		vi.stubGlobal('BroadcastChannel', undefined)
+		const real = fakeRealClient()
+		expect(withTabSharing()(real.client)).toBe(real.client)
+	})
+
+	it('leader opens one real connection and fans messages out to followers', async () => {
+		const real = fakeRealClient()
+		const shared = withTabSharing()(real.client)
+
+		const tab1 = await shared.openConnection(() => {})
+		const tab2 = await shared.openConnection(() => {})
+		await flush()
+
+		const got1: unknown[] = []
+		const got2: unknown[] = []
+		await tab1.subscribe('news', (m) => got1.push(m), () => {})
+		await tab2.subscribe('news', (m) => got2.push(m), () => {})
+		await flush()
+
+		expect(real.opened).toBe(1)
+		expect(real.subscribed).toEqual(['news'])
+
+		real.publish('news', 'hello')
+		await flush()
+		expect(got1).toEqual(['hello'])
+		expect(got2).toEqual(['hello'])
+	})
+
+	it('refcounts interest: real unsubscribe only when the last tab leaves', async () => {
+		const real = fakeRealClient()
+		const shared = withTabSharing()(real.client)
+
+		const tab1 = await shared.openConnection(() => {})
+		const tab2 = await shared.openConnection(() => {})
+		await flush()
+
+		const un1 = await tab1.subscribe('news', () => {}, () => {})
+		const un2 = await tab2.subscribe('news', () => {}, () => {})
+		await flush()
+
+		un2()
+		await flush()
+		expect(real.unsubscribed).toEqual([])
+
+		un1()
+		await flush()
+		expect(real.unsubscribed).toEqual(['news'])
+	})
+
+	it('leader handoff: follower takes over, re-subscribes, and resyncs via onReconnect', async () => {
+		const real = fakeRealClient()
+		const shared = withTabSharing()(real.client)
+
+		const tab1 = await shared.openConnection(() => {})
+		let tab2Reconnects = 0
+		const tab2 = await shared.openConnection(() => tab2Reconnects++)
+		await flush()
+
+		await tab2.subscribe('news', () => {}, () => {})
+		await flush()
+		expect(real.subscribed).toEqual(['news'])
+
+		tab1.close()
+		await flush(50)
+
+		// tab2 became leader: opened its own real connection + re-subscribed its channel
+		expect(real.opened).toBe(2)
+		expect(real.subscribed).toEqual(['news', 'news'])
+		// and resynced its liveQueries (it was riding the dead leader's connection)
+		expect(tab2Reconnects).toBe(1)
+	})
+
+	it('real SSE reconnect fans onReconnect out to every tab', async () => {
+		const real = fakeRealClient()
+		const shared = withTabSharing()(real.client)
+
+		let leaderReconnects = 0
+		let followerReconnects = 0
+		await shared.openConnection(() => leaderReconnects++)
+		await shared.openConnection(() => followerReconnects++)
+		await flush()
+
+		real.fireReconnect()
+		await flush()
+
+		expect(leaderReconnects).toBe(1)
+		expect(followerReconnects).toBe(1)
+	})
+})

--- a/packages/firstly/src/lib/core/subscriptionClientStack.spec.ts
+++ b/packages/firstly/src/lib/core/subscriptionClientStack.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
 import type { SubscriptionClient, SubscriptionClientConnection } from 'remult'
 
 import { stackSubscriptionClient, withTabSharing } from './subscriptionClientStack'
@@ -121,8 +122,16 @@ describe('withTabSharing', () => {
 
 		const got1: unknown[] = []
 		const got2: unknown[] = []
-		await tab1.subscribe('news', (m) => got1.push(m), () => {})
-		await tab2.subscribe('news', (m) => got2.push(m), () => {})
+		await tab1.subscribe(
+			'news',
+			(m) => got1.push(m),
+			() => {},
+		)
+		await tab2.subscribe(
+			'news',
+			(m) => got2.push(m),
+			() => {},
+		)
 		await flush()
 
 		expect(real.opened).toBe(1)
@@ -142,8 +151,16 @@ describe('withTabSharing', () => {
 		const tab2 = await shared.openConnection(() => {})
 		await flush()
 
-		const un1 = await tab1.subscribe('news', () => {}, () => {})
-		const un2 = await tab2.subscribe('news', () => {}, () => {})
+		const un1 = await tab1.subscribe(
+			'news',
+			() => {},
+			() => {},
+		)
+		const un2 = await tab2.subscribe(
+			'news',
+			() => {},
+			() => {},
+		)
 		await flush()
 
 		un2()
@@ -164,7 +181,11 @@ describe('withTabSharing', () => {
 		const tab2 = await shared.openConnection(() => tab2Reconnects++)
 		await flush()
 
-		await tab2.subscribe('news', () => {}, () => {})
+		await tab2.subscribe(
+			'news',
+			() => {},
+			() => {},
+		)
 		await flush()
 		expect(real.subscribed).toEqual(['news'])
 

--- a/packages/firstly/src/lib/core/subscriptionClientStack.ts
+++ b/packages/firstly/src/lib/core/subscriptionClientStack.ts
@@ -1,0 +1,359 @@
+import {
+	remult,
+	type SubscriptionClient,
+	type SubscriptionClientConnection,
+	type Unsubscribe,
+} from 'remult'
+
+export type SubscriptionClientMiddleware = (next: SubscriptionClient) => SubscriptionClient
+
+/**
+ * Compose a `SubscriptionClient` from middlewares, with `directSseSubscriptionClient`
+ * at the bottom of the stack. With no middlewares, you get the bare direct SSE client.
+ *
+ * ```ts
+ * remult.apiClient.subscriptionClient = stackSubscriptionClient(withTabSharing())
+ * ```
+ */
+export function stackSubscriptionClient(
+	...middlewares: SubscriptionClientMiddleware[]
+): SubscriptionClient {
+	return middlewares.reduceRight<SubscriptionClient>(
+		(next, mw) => mw(next),
+		directSseSubscriptionClient(),
+	)
+}
+
+const BUS_NAME = 'ff-sse-bus'
+const LOCK_NAME = 'ff-sse-leader'
+
+type BusMessage =
+	| { type: 'leader:hello' }
+	| { type: 'reconnect' }
+	| { type: 'follower:channels'; tabId: string; channels: string[] }
+	| { type: 'follower:subscribe'; tabId: string; channel: string }
+	| { type: 'follower:unsubscribe'; tabId: string; channel: string }
+	| { type: 'follower:bye'; tabId: string }
+	| { type: 'message'; channel: string; data: unknown }
+
+/**
+ * Middleware that shares ONE real SSE connection across all tabs of the same origin.
+ *
+ * Why: the browser's HTTP/1.1 ~6-connections-per-domain limit. With one EventSource
+ * per tab, opening 5+ tabs starves all other HTTP requests on the domain.
+ *
+ * How: `navigator.locks` elects a single leader tab. The leader opens the underlying
+ * (next) `SubscriptionClient` and forwards every channel message over a
+ * `BroadcastChannel` to follower tabs. Followers ask the leader to (un)subscribe
+ * the channels they care about; the leader refcounts interest per tab. On leader
+ * death (close/refresh), the lock is released and the next tab takes over,
+ * re-subscribing every channel any surviving tab still cares about.
+ *
+ * liveQuery support: a leader handoff and a real SSE reconnect both fan out a
+ * `reconnect` signal so EVERY tab fires its own `onReconnect`. Remult's
+ * LiveQueryClient then re-runs each query (refetch + resubscribe), covering
+ * messages lost in the gap. Plain `SubscriptionChannel` fanout works too, with the
+ * usual SSE semantics (no replay of messages missed during a reconnect).
+ */
+export function withTabSharing(): SubscriptionClientMiddleware {
+	return (next) => {
+		if (
+			typeof window === 'undefined' ||
+			typeof BroadcastChannel === 'undefined' ||
+			typeof navigator === 'undefined' ||
+			!('locks' in navigator)
+		) {
+			return next
+		}
+
+		return {
+			openConnection(onReconnect) {
+				return Promise.resolve(createSharedConnection(next, onReconnect))
+			},
+		}
+	}
+}
+
+function createSharedConnection(
+	realClient: SubscriptionClient,
+	onReconnect: VoidFunction,
+): SubscriptionClientConnection {
+	const tabId =
+		typeof crypto !== 'undefined' && crypto.randomUUID
+			? crypto.randomUUID()
+			: Math.random().toString(36).slice(2)
+	const localHandlers = new Map<string, Set<(message: unknown) => void>>()
+	const bus = new BroadcastChannel(BUS_NAME)
+	let isLeader = false
+	// True once another tab's leader served us - a later takeover is then a handoff.
+	let sawRemoteLeader = false
+	let leaderConnection: SubscriptionClientConnection | undefined
+	// Leader state: real subscription per channel + which tabs still want it.
+	const realSubs = new Map<string, Promise<Unsubscribe>>()
+	const interest = new Map<string, Set<string>>()
+	let closed = false
+	let closeResolver: (() => void) | undefined
+
+	const dispatchLocally = (channel: string, message: unknown) => {
+		const handlers = localHandlers.get(channel)
+		if (handlers) handlers.forEach((h) => h(message))
+	}
+
+	const addInterest = (channel: string, forTab: string) => {
+		let tabs = interest.get(channel)
+		if (!tabs) interest.set(channel, (tabs = new Set()))
+		tabs.add(forTab)
+	}
+
+	const ensureRealSubscribed = async (channel: string, forTab: string) => {
+		if (!isLeader || !leaderConnection) return
+		addInterest(channel, forTab)
+		if (realSubs.has(channel)) return
+		const promise = leaderConnection.subscribe(
+			channel,
+			(data) => {
+				dispatchLocally(channel, data)
+				bus.postMessage({ type: 'message', channel, data } satisfies BusMessage)
+			},
+			(err) => {
+				console.error('[withTabSharing] channel error', channel, err)
+			},
+		)
+		realSubs.set(channel, promise)
+		await promise
+	}
+
+	const dropInterest = (channel: string, forTab: string) => {
+		if (!isLeader) return
+		const tabs = interest.get(channel)
+		if (!tabs) return
+		tabs.delete(forTab)
+		if (tabs.size > 0) return
+		interest.delete(channel)
+		const sub = realSubs.get(channel)
+		if (sub) {
+			realSubs.delete(channel)
+			sub.then((unsub) => unsub()).catch(() => {})
+		}
+	}
+
+	const dropTab = (forTab: string) => {
+		if (!isLeader) return
+		for (const channel of [...interest.keys()]) {
+			dropInterest(channel, forTab)
+		}
+	}
+
+	bus.onmessage = async (e) => {
+		const msg = e.data as BusMessage
+		switch (msg.type) {
+			case 'message':
+				dispatchLocally(msg.channel, msg.data)
+				break
+			case 'reconnect':
+				if (!isLeader) onReconnect()
+				break
+			case 'follower:subscribe':
+				if (isLeader) await ensureRealSubscribed(msg.channel, msg.tabId)
+				break
+			case 'follower:unsubscribe':
+				dropInterest(msg.channel, msg.tabId)
+				break
+			case 'follower:bye':
+				dropTab(msg.tabId)
+				break
+			case 'follower:channels':
+				if (isLeader) {
+					for (const ch of msg.channels) await ensureRealSubscribed(ch, msg.tabId)
+				}
+				break
+			case 'leader:hello':
+				if (!isLeader) {
+					const isHandoff = sawRemoteLeader
+					sawRemoteLeader = true
+					bus.postMessage({
+						type: 'follower:channels',
+						tabId,
+						channels: [...localHandlers.keys()],
+					} satisfies BusMessage)
+					// New leader means the previous SSE connection died with our
+					// subscriptions on it - resync liveQueries.
+					if (isHandoff) onReconnect()
+				}
+				break
+		}
+	}
+
+	navigator.locks
+		.request(LOCK_NAME, { mode: 'exclusive' }, async () => {
+			if (closed) return
+			try {
+				leaderConnection = await realClient.openConnection(() => {
+					// Real SSE reconnected: resync every tab, not just the leader.
+					onReconnect()
+					bus.postMessage({ type: 'reconnect' } satisfies BusMessage)
+				})
+				isLeader = true
+				for (const ch of localHandlers.keys()) {
+					await ensureRealSubscribed(ch, tabId)
+				}
+				bus.postMessage({ type: 'leader:hello' } satisfies BusMessage)
+				// We were riding a dead leader's connection - resync our own queries.
+				if (sawRemoteLeader) onReconnect()
+			} catch (err) {
+				console.error('[withTabSharing] failed to become leader', err)
+				return
+			}
+			await new Promise<void>((resolve) => {
+				if (closed) resolve()
+				closeResolver = resolve
+			})
+		})
+		.catch((err) => {
+			console.error('[withTabSharing] lock request failed', err)
+		})
+
+	return {
+		close() {
+			if (closed) return
+			closed = true
+			try {
+				bus.postMessage({ type: 'follower:bye', tabId } satisfies BusMessage)
+				bus.close()
+			} catch {
+				// bus may already be gone (tab teardown)
+			}
+			if (leaderConnection) {
+				try {
+					leaderConnection.close()
+				} catch {
+					// best effort
+				}
+			}
+			closeResolver?.()
+		},
+		async subscribe(channel, onMessage, _onError) {
+			let handlers = localHandlers.get(channel)
+			if (!handlers) {
+				handlers = new Set()
+				localHandlers.set(channel, handlers)
+			}
+			handlers.add(onMessage)
+
+			if (isLeader) {
+				await ensureRealSubscribed(channel, tabId)
+			} else {
+				bus.postMessage({ type: 'follower:subscribe', tabId, channel } satisfies BusMessage)
+			}
+
+			return () => {
+				const set = localHandlers.get(channel)
+				if (!set) return
+				set.delete(onMessage)
+				if (set.size === 0) {
+					localHandlers.delete(channel)
+					if (isLeader) {
+						dropInterest(channel, tabId)
+					} else {
+						bus.postMessage({
+							type: 'follower:unsubscribe',
+							tabId,
+							channel,
+						} satisfies BusMessage)
+					}
+				}
+			}
+		},
+	}
+}
+
+/**
+ * Minimal direct SSE-based `SubscriptionClient` - mirrors Remult's internal
+ * `SseSubscriptionClient`. Inlined because Remult does not publicly export it.
+ */
+export function directSseSubscriptionClient(): SubscriptionClient {
+	return {
+		openConnection(onReconnect) {
+			const channels = new Map<string, ((message: unknown) => void)[]>()
+			let connectionId: string | undefined
+			let source: EventSource | undefined
+			let connected = false
+			let retryCount = 0
+
+			const baseUrl = remult.apiClient.url ?? '/api'
+			const streamUrl = `${baseUrl}/stream`
+
+			const post = async (path: string, body: unknown) => {
+				const res = await fetch(`${streamUrl}/${path}`, {
+					method: 'POST',
+					credentials: 'include',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(body),
+				})
+				return res.json().catch(() => null)
+			}
+
+			const subscribeOnServer = async (channel: string) => {
+				if (!connectionId) return
+				await post('subscribe', { channel, clientId: connectionId })
+			}
+
+			const open = (resolveOnce: (c: SubscriptionClientConnection) => void) => {
+				if (source) source.close()
+				source = new EventSource(streamUrl, { withCredentials: true })
+
+				source.onmessage = (e) => {
+					try {
+						const msg = JSON.parse(e.data) as { channel: string; data: unknown }
+						const listeners = channels.get(msg.channel)
+						if (listeners) listeners.forEach((l) => l(msg.data))
+					} catch (err) {
+						console.error('[directSseSubscriptionClient] parse error', err)
+					}
+				}
+
+				source.onerror = () => {
+					source?.close()
+					if (retryCount++ < 10) setTimeout(open, 500, resolveOnce)
+				}
+
+				source.addEventListener('connectionId', async (e) => {
+					connectionId = (e as MessageEvent).data
+					if (connected) {
+						for (const ch of channels.keys()) await subscribeOnServer(ch)
+						onReconnect()
+					} else {
+						connected = true
+						resolveOnce(connection)
+					}
+				})
+			}
+
+			const connection: SubscriptionClientConnection = {
+				close() {
+					source?.close()
+				},
+				async subscribe(channel, handler, _onError) {
+					let listeners = channels.get(channel)
+					if (!listeners) {
+						channels.set(channel, (listeners = []))
+						await subscribeOnServer(channel)
+					}
+					listeners.push(handler)
+					return () => {
+						const idx = listeners!.indexOf(handler)
+						if (idx >= 0) listeners!.splice(idx, 1)
+						if (listeners!.length === 0) {
+							channels.delete(channel)
+							if (connectionId) {
+								post('unsubscribe', { channel, clientId: connectionId }).catch(() => {})
+							}
+						}
+					}
+				},
+			}
+
+			return new Promise<SubscriptionClientConnection>((resolve) => open(resolve))
+		},
+	}
+}

--- a/packages/firstly/src/lib/index.ts
+++ b/packages/firstly/src/lib/index.ts
@@ -22,8 +22,18 @@ export { errorMessage, isError } from './core/helper.js'
 export { tryCatch, tryCatchSync } from './core/tryCatch.js'
 export type { ResolvedType, UnArray, RecursivePartial } from './core/types.js'
 export { tw } from './core/tailwind.js'
-export { stackHttpClient, withHeader } from './core/httpClientStack.js'
-export type { HttpClientFetch, HttpClientMiddleware } from './core/httpClientStack.js'
+export { stackHttpClient, withHeader, withShortTermCache } from './core/httpClientStack.js'
+export type {
+	HttpClientFetch,
+	HttpClientMiddleware,
+	ShortTermCacheOptions,
+} from './core/httpClientStack.js'
+export {
+	stackSubscriptionClient,
+	withTabSharing,
+	directSseSubscriptionClient,
+} from './core/subscriptionClientStack.js'
+export type { SubscriptionClientMiddleware } from './core/subscriptionClientStack.js'
 
 // Misc primitives still exposed from the root.
 export { FF_LogToConsole } from './SqlDatabase/FF_LogToConsole.js'


### PR DESCRIPTION
- `withShortTermCache`: fetch middleware that dedupes identical read requests (GET + remult's `__action=get|groupBy` POSTs) within a short TTL - a tiny client-side cache. Exported from `'firstly'` next to `stackHttpClient`/`withHeader`.
- `stackSubscriptionClient` + `withTabSharing` + `directSseSubscriptionClient`: one shared SSE connection across all tabs (leader elected via `navigator.locks`, fanout over `BroadcastChannel`), promoted from app-land.
- liveQuery now works with tab sharing: leader handoff and real SSE reconnects broadcast a resync so every tab fires its own `onReconnect`; channel interest is refcounted per tab so real unsubscribes happen when the last tab leaves.