### PR TITLE
feat(svelte): export ffTrapFocus from firstly/svelte

### DIFF
--- a/.changeset/export-ff-trap-focus.md
+++ b/.changeset/export-ff-trap-focus.md
@@ -1,0 +1,5 @@
+---
+"firstly": patch
+---
+
+svelte: re-export `ffTrapFocus` from `firstly/svelte` so custom dialog shells can trap Tab focus without copying the implementation.

--- a/packages/firstly/src/lib/svelte/index.ts
+++ b/packages/firstly/src/lib/svelte/index.ts
@@ -14,7 +14,7 @@ export type {
 } from './ff.svelte.js'
 export { infiniteScroll } from './infiniteScroll.js'
 export type { InfiniteScrollOptions } from './infiniteScroll.js'
-export { dialog, ffAutofocus, resolveMessage } from './dialog.svelte.js'
+export { dialog, ffAutofocus, ffTrapFocus, resolveMessage } from './dialog.svelte.js'
 export type {
 	DialogResult,
 	DialogClose,


### PR DESCRIPTION
Closes #319

`ffTrapFocus` already exists in `dialog.svelte.js` (used by the built-in shell) but was not re-exported from `firstly/svelte`. Custom dialog shells had to copy it. Now exported alongside `ffAutofocus`.