### PR TITLE
feat(svelte): stackHandleClientError + withStaleDeployReload for hooks.client.js

### DIFF
--- a/.changeset/ff-handle-error.md
+++ b/.changeset/ff-handle-error.md
@@ -2,4 +2,4 @@
 "firstly": minor
 ---
 
-svelte: add `ffHandleError`, a composable `handleError` for `hooks.client.js` that recovers stale-deploy chunk-load failures with a one-shot hard reload (time-boxed guard, no reload loop) and delegates every other error to your own `onError`. Trusts the failure signal instead of `updated.check()`, which lies behind a CDN caching `version.json`.
+svelte: add `ffHandleError(onError?)`, a composable `handleError` for `hooks.client.js`. It hard-reloads once on a stale-deploy chunk-load failure (time-boxed guard, no reload loop) and delegates every other error to your handler. Trusts the failure signal instead of `updated.check()`, which lies behind a CDN caching `version.json`.

--- a/.changeset/ff-handle-error.md
+++ b/.changeset/ff-handle-error.md
@@ -2,4 +2,4 @@
 "firstly": minor
 ---
 
-svelte: add `ffHandleError(onError?)`, a composable `handleError` for `hooks.client.js`. It hard-reloads once on a stale-deploy chunk-load failure (time-boxed guard, no reload loop) and delegates every other error to your handler. Trusts the failure signal instead of `updated.check()`, which lies behind a CDN caching `version.json`.
+svelte: add `stackHandleClientError(...middlewares)` and a `withStaleDeployReload()` middleware for `hooks.client.js`, mirroring `stackHttpClient`. Stack your own error handlers alongside stale-deploy recovery: `withStaleDeployReload` hard-reloads once on a chunk-load failure (time-boxed guard, no reload loop), trusting the failure signal instead of `updated.check()` (which lies behind a CDN caching `version.json`).

--- a/.changeset/ff-handle-error.md
+++ b/.changeset/ff-handle-error.md
@@ -1,0 +1,5 @@
+---
+"firstly": minor
+---
+
+svelte: add `ffHandleError`, a composable `handleError` for `hooks.client.js` that recovers stale-deploy chunk-load failures with a one-shot hard reload (time-boxed guard, no reload loop) and delegates every other error to your own `onError`. Trusts the failure signal instead of `updated.check()`, which lies behind a CDN caching `version.json`.

--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -287,6 +287,27 @@ functions for i18n). `many.confirmRemove` uses `toast.fromError` on a failed del
 user or network/error text (XSS). `toast.fromError` HTML-escapes its extracted message, so error text
 is always safe to show; titles are always plain text.
 
+## `ffHandleError` - recover stale-deploy chunk failures
+
+`ffHandleError` (from `firstly/svelte`) wraps `hooks.client.js`'s `handleError`. After a deploy an
+open client (esp. SPA builds) 404s on a lazy chunk; SvelteKit's `updated.check()` recovery lies
+behind a CDN caching `version.json`. `ffHandleError` trusts the failure signal instead: on a
+chunk-load error it hard-reloads once (time-boxed one-shot guard, no reload loop), and delegates
+every other error to your handler.
+
+```js
+// src/hooks.client.js
+import { ffHandleError } from 'firstly/svelte'
+
+export const handleError = ffHandleError(({ error }) => {
+	report(error) // your logging
+	return { message: 'Oops' }
+})
+```
+
+No handler → returns `{ message: 'Something went wrong' }`. Only chunk-load errors reload (a blind
+404 reload would break client-side not-found routes).
+
 ## i18n - `LocalizedMessage`
 
 firstly's localizable-string convention (from `createValidators`, reused by `dialog.confirm`):

--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -287,26 +287,31 @@ functions for i18n). `many.confirmRemove` uses `toast.fromError` on a failed del
 user or network/error text (XSS). `toast.fromError` HTML-escapes its extracted message, so error text
 is always safe to show; titles are always plain text.
 
-## `ffHandleError` - recover stale-deploy chunk failures
+## `stackHandleClientError` - stack `hooks.client.js` error handlers
 
-`ffHandleError` (from `firstly/svelte`) wraps `hooks.client.js`'s `handleError`. After a deploy an
-open client (esp. SPA builds) 404s on a lazy chunk; SvelteKit's `updated.check()` recovery lies
-behind a CDN caching `version.json`. `ffHandleError` trusts the failure signal instead: on a
-chunk-load error it hard-reloads once (time-boxed one-shot guard, no reload loop), and delegates
-every other error to your handler.
+`stackHandleClientError` (from `firstly/svelte`) composes `handleError` middlewares, mirroring
+`stackHttpClient`. Middlewares run outermost-first; each either short-circuits (return without
+calling `next`) or calls `next(input)`. The base returns `{ message: 'Something went wrong' }`.
+
+`withStaleDeployReload()` is the built-in middleware: after a deploy an open client (esp. SPA builds)
+404s on a lazy chunk; SvelteKit's `updated.check()` recovery lies behind a CDN caching `version.json`.
+It trusts the failure signal instead - on a chunk-load error it hard-reloads once (time-boxed
+one-shot guard, no reload loop), passing every other error to `next`.
 
 ```js
 // src/hooks.client.js
-import { ffHandleError } from 'firstly/svelte'
+import { stackHandleClientError, withStaleDeployReload } from 'firstly/svelte'
 
-export const handleError = ffHandleError(({ error }) => {
-	report(error) // your logging
-	return { message: 'Oops' }
-})
+export const handleError = stackHandleClientError(
+	withStaleDeployReload(),
+	(next) => (input) => {
+		report(input.error) // your logging
+		return next(input) // or return { message: 'Oops' } to stop here
+	},
+)
 ```
 
-No handler → returns `{ message: 'Something went wrong' }`. Only chunk-load errors reload (a blind
-404 reload would break client-side not-found routes).
+Only chunk-load errors reload (a blind 404 reload would break client-side not-found routes).
 
 ## i18n - `LocalizedMessage`
 

--- a/packages/firstly/src/lib/svelte/handleError.spec.ts
+++ b/packages/firstly/src/lib/svelte/handleError.spec.ts
@@ -4,11 +4,11 @@ import { ffHandleError } from './handleError'
 
 const CHUNK_MSG = 'Failed to fetch dynamically imported module: /_app/immutable/x.js'
 
-function input(over: { message?: string; status?: number; href?: string } = {}) {
+function input(over: { message?: string; href?: string } = {}) {
 	return {
 		error: new Error(over.message ?? 'boom'),
 		message: over.message ?? 'boom',
-		status: over.status ?? 500,
+		status: 500,
 		event: { url: new URL(over.href ?? 'https://app.test/page') },
 	} as unknown as Parameters<ReturnType<typeof ffHandleError>>[0]
 }
@@ -37,7 +37,7 @@ describe('ffHandleError', () => {
 	})
 
 	it('does not reload twice for the same url (loop guard)', () => {
-		const handle = ffHandleError({ onError: () => ({ message: 'broken' }) })
+		const handle = ffHandleError(() => ({ message: 'broken' }))
 		handle(input({ message: CHUNK_MSG }))
 		const res = handle(input({ message: CHUNK_MSG }))
 		expect(assign).toHaveBeenCalledTimes(1)
@@ -46,9 +46,9 @@ describe('ffHandleError', () => {
 
 	it('retries again after the guard window elapses', () => {
 		vi.useFakeTimers()
-		const handle = ffHandleError({ retryWindowMs: 1000 })
+		const handle = ffHandleError()
 		handle(input({ message: CHUNK_MSG }))
-		vi.advanceTimersByTime(1500)
+		vi.advanceTimersByTime(11_000)
 		handle(input({ message: CHUNK_MSG }))
 		expect(assign).toHaveBeenCalledTimes(2)
 		vi.useRealTimers()
@@ -56,20 +56,13 @@ describe('ffHandleError', () => {
 
 	it('ignores non-chunk errors and delegates to onError', () => {
 		const onError = vi.fn(() => ({ message: 'logged' }))
-		const res = ffHandleError({ onError })(input({ message: 'random' }))
+		const res = ffHandleError(onError)(input({ message: 'random' }))
 		expect(assign).not.toHaveBeenCalled()
 		expect(onError).toHaveBeenCalledOnce()
 		expect(res).toEqual({ message: 'logged' })
 	})
 
-	it('leaves 404s alone unless recoverOn404 is set', () => {
-		ffHandleError()(input({ status: 404, message: 'Not found' }))
-		expect(assign).not.toHaveBeenCalled()
-		ffHandleError({ recoverOn404: true })(input({ status: 404, message: 'Not found' }))
-		expect(assign).toHaveBeenCalledOnce()
-	})
-
-	it('falls back to a default message with no onError', () => {
+	it('falls back to a default message with no handler', () => {
 		expect(ffHandleError()(input({ message: 'random' }))).toEqual({ message: 'Something went wrong' })
 	})
 })

--- a/packages/firstly/src/lib/svelte/handleError.spec.ts
+++ b/packages/firstly/src/lib/svelte/handleError.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ffHandleError } from './handleError'
+import { stackHandleClientError, withStaleDeployReload } from './handleError'
 
 const CHUNK_MSG = 'Failed to fetch dynamically imported module: /_app/immutable/x.js'
 
@@ -10,7 +10,7 @@ function input(over: { message?: string; href?: string } = {}) {
 		message: over.message ?? 'boom',
 		status: 500,
 		event: { url: new URL(over.href ?? 'https://app.test/page') },
-	} as unknown as Parameters<ReturnType<typeof ffHandleError>>[0]
+	} as unknown as Parameters<ReturnType<typeof stackHandleClientError>>[0]
 }
 
 let store: Record<string, string>
@@ -29,40 +29,64 @@ beforeEach(() => {
 
 afterEach(() => vi.unstubAllGlobals())
 
-describe('ffHandleError', () => {
+describe('stackHandleClientError', () => {
+	it('runs middlewares outermost-first and returns the base message', () => {
+		const calls: string[] = []
+		const trace =
+			(name: string): Parameters<typeof stackHandleClientError>[0] =>
+			(next) =>
+			(i) => {
+				calls.push(name)
+				return next(i)
+			}
+		const res = stackHandleClientError(trace('a'), trace('b'))(input())
+		expect(calls).toEqual(['a', 'b'])
+		expect(res).toEqual({ message: 'Something went wrong' })
+	})
+
+	it('lets a middleware short-circuit without calling next', () => {
+		const later = vi.fn()
+		const res = stackHandleClientError(
+			() => () => ({ message: 'stop' }),
+			(next) => (i) => {
+				later()
+				return next(i)
+			},
+		)(input())
+		expect(res).toEqual({ message: 'stop' })
+		expect(later).not.toHaveBeenCalled()
+	})
+})
+
+describe('withStaleDeployReload', () => {
+	const handle = (over?: Parameters<typeof input>[0]) =>
+		stackHandleClientError(withStaleDeployReload(), () => () => ({ message: 'logged' }))(input(over))
+
 	it('hard-reloads once on a chunk-load failure', () => {
-		const res = ffHandleError()(input({ message: CHUNK_MSG }))
+		const res = handle({ message: CHUNK_MSG })
 		expect(assign).toHaveBeenCalledWith('https://app.test/page')
 		expect(res).toBeUndefined()
 	})
 
 	it('does not reload twice for the same url (loop guard)', () => {
-		const handle = ffHandleError(() => ({ message: 'broken' }))
-		handle(input({ message: CHUNK_MSG }))
-		const res = handle(input({ message: CHUNK_MSG }))
+		handle({ message: CHUNK_MSG })
+		const res = handle({ message: CHUNK_MSG })
 		expect(assign).toHaveBeenCalledTimes(1)
-		expect(res).toEqual({ message: 'broken' })
+		expect(res).toEqual({ message: 'logged' })
 	})
 
 	it('retries again after the guard window elapses', () => {
 		vi.useFakeTimers()
-		const handle = ffHandleError()
-		handle(input({ message: CHUNK_MSG }))
+		handle({ message: CHUNK_MSG })
 		vi.advanceTimersByTime(11_000)
-		handle(input({ message: CHUNK_MSG }))
+		handle({ message: CHUNK_MSG })
 		expect(assign).toHaveBeenCalledTimes(2)
 		vi.useRealTimers()
 	})
 
-	it('ignores non-chunk errors and delegates to onError', () => {
-		const onError = vi.fn(() => ({ message: 'logged' }))
-		const res = ffHandleError(onError)(input({ message: 'random' }))
+	it('passes non-chunk errors through to next', () => {
+		const res = handle({ message: 'random' })
 		expect(assign).not.toHaveBeenCalled()
-		expect(onError).toHaveBeenCalledOnce()
 		expect(res).toEqual({ message: 'logged' })
-	})
-
-	it('falls back to a default message with no handler', () => {
-		expect(ffHandleError()(input({ message: 'random' }))).toEqual({ message: 'Something went wrong' })
 	})
 })

--- a/packages/firstly/src/lib/svelte/handleError.spec.ts
+++ b/packages/firstly/src/lib/svelte/handleError.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ffHandleError } from './handleError'
+
+const CHUNK_MSG = 'Failed to fetch dynamically imported module: /_app/immutable/x.js'
+
+function input(over: { message?: string; status?: number; href?: string } = {}) {
+	return {
+		error: new Error(over.message ?? 'boom'),
+		message: over.message ?? 'boom',
+		status: over.status ?? 500,
+		event: { url: new URL(over.href ?? 'https://app.test/page') },
+	} as unknown as Parameters<ReturnType<typeof ffHandleError>>[0]
+}
+
+let store: Record<string, string>
+let assign: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+	store = {}
+	assign = vi.fn()
+	vi.stubGlobal('sessionStorage', {
+		getItem: (k: string) => store[k] ?? null,
+		setItem: (k: string, v: string) => void (store[k] = v),
+		removeItem: (k: string) => void delete store[k],
+	})
+	vi.stubGlobal('location', { assign })
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('ffHandleError', () => {
+	it('hard-reloads once on a chunk-load failure', () => {
+		const res = ffHandleError()(input({ message: CHUNK_MSG }))
+		expect(assign).toHaveBeenCalledWith('https://app.test/page')
+		expect(res).toBeUndefined()
+	})
+
+	it('does not reload twice for the same url (loop guard)', () => {
+		const handle = ffHandleError({ onError: () => ({ message: 'broken' }) })
+		handle(input({ message: CHUNK_MSG }))
+		const res = handle(input({ message: CHUNK_MSG }))
+		expect(assign).toHaveBeenCalledTimes(1)
+		expect(res).toEqual({ message: 'broken' })
+	})
+
+	it('retries again after the guard window elapses', () => {
+		vi.useFakeTimers()
+		const handle = ffHandleError({ retryWindowMs: 1000 })
+		handle(input({ message: CHUNK_MSG }))
+		vi.advanceTimersByTime(1500)
+		handle(input({ message: CHUNK_MSG }))
+		expect(assign).toHaveBeenCalledTimes(2)
+		vi.useRealTimers()
+	})
+
+	it('ignores non-chunk errors and delegates to onError', () => {
+		const onError = vi.fn(() => ({ message: 'logged' }))
+		const res = ffHandleError({ onError })(input({ message: 'random' }))
+		expect(assign).not.toHaveBeenCalled()
+		expect(onError).toHaveBeenCalledOnce()
+		expect(res).toEqual({ message: 'logged' })
+	})
+
+	it('leaves 404s alone unless recoverOn404 is set', () => {
+		ffHandleError()(input({ status: 404, message: 'Not found' }))
+		expect(assign).not.toHaveBeenCalled()
+		ffHandleError({ recoverOn404: true })(input({ status: 404, message: 'Not found' }))
+		expect(assign).toHaveBeenCalledOnce()
+	})
+
+	it('falls back to a default message with no onError', () => {
+		expect(ffHandleError()(input({ message: 'random' }))).toEqual({ message: 'Something went wrong' })
+	})
+})

--- a/packages/firstly/src/lib/svelte/handleError.ts
+++ b/packages/firstly/src/lib/svelte/handleError.ts
@@ -1,0 +1,81 @@
+import type { HandleClientError } from '@sveltejs/kit'
+
+// Errors SvelteKit/Vite throw when a lazy chunk 404s after a deploy.
+const CHUNK_LOAD_RE =
+	/Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/
+
+type HandleClientErrorInput = Parameters<HandleClientError>[0]
+
+export interface FfHandleErrorOptions {
+	/** Matches chunk-load error messages. Default covers Vite/SvelteKit wording. */
+	chunkLoadPattern?: RegExp
+	/** `sessionStorage` key for the one-shot reload guard. Default `ff-reload`. */
+	storageKey?: string
+	/**
+	 * How long (ms) a just-reloaded URL is treated as "already retried". A second
+	 * failure inside this window is a genuine break and falls through to `onError`.
+	 * Default 10000. Avoids needing an `afterNavigate` to clear the guard.
+	 */
+	retryWindowMs?: number
+	/**
+	 * Also treat a bare 404 as a stale-deploy failure. Off by default: it would
+	 * hard-reload legitimate client-side "not found" routes. Turn on for SPA hosts
+	 * where a missing chunk surfaces as a 404 with no chunk-load message.
+	 */
+	recoverOn404?: boolean
+	/** Your own handler for errors that were not recovered (logging, custom UX). */
+	onError?: HandleClientError
+}
+
+const DEFAULT_MESSAGE = 'Something went wrong'
+
+/**
+ * Composable `handleError` for `hooks.client.js` that recovers stale-deploy chunk
+ * failures by hard-reloading once, then delegates everything else to your `onError`.
+ *
+ * ```js
+ * // src/hooks.client.js
+ * export const handleError = ffHandleError({
+ *   onError: ({ error }) => { report(error); return { message: 'Oops' } },
+ * })
+ * ```
+ *
+ * The reload trusts the failure signal itself, not `updated.check()` (which lies
+ * behind a CDN caching `version.json`). A time-boxed one-shot guard prevents loops.
+ */
+export function ffHandleError(options: FfHandleErrorOptions = {}): HandleClientError {
+	const pattern = options.chunkLoadPattern ?? CHUNK_LOAD_RE
+	const key = options.storageKey ?? 'ff-reload'
+	const windowMs = options.retryWindowMs ?? 10_000
+
+	return (input: HandleClientErrorInput) => {
+		const looksStale =
+			(options.recoverOn404 === true && input.status === 404) ||
+			pattern.test(String(input.message))
+
+		if (looksStale && reloadOnce(key, windowMs, input.event.url.href)) {
+			return // page is unloading; no error surfaces
+		}
+
+		return options.onError?.(input) ?? { message: DEFAULT_MESSAGE }
+	}
+}
+
+/** Hard-reload `href` unless it already failed within `windowMs`. Returns true if reloading. */
+function reloadOnce(key: string, windowMs: number, href: string): boolean {
+	try {
+		const prev = sessionStorage.getItem(key)
+		if (prev) {
+			const [prevHref, prevAt] = prev.split('\n')
+			if (prevHref === href && Date.now() - Number(prevAt) < windowMs) {
+				sessionStorage.removeItem(key) // genuine break -> stop retrying
+				return false
+			}
+		}
+		sessionStorage.setItem(key, `${href}\n${Date.now()}`)
+		location.assign(href) // bypasses SvelteKit's stale version check
+		return true
+	} catch {
+		return false // no sessionStorage (private mode) -> don't risk a loop
+	}
+}

--- a/packages/firstly/src/lib/svelte/handleError.ts
+++ b/packages/firstly/src/lib/svelte/handleError.ts
@@ -1,5 +1,37 @@
 import type { HandleClientError } from '@sveltejs/kit'
 
+type HandleClientErrorInput = Parameters<HandleClientError>[0]
+
+export type HandleClientErrorMiddleware = (next: HandleClientError) => HandleClientError
+
+/**
+ * Compose `handleError` middlewares into a single `hooks.client.js` handler.
+ * Middlewares run outermost-first (the first argument wraps the rest). A middleware
+ * either short-circuits (return without calling `next` - e.g. a hard reload) or calls
+ * `next(input)`. The base returns `{ message: 'Something went wrong' }`.
+ *
+ * ```js
+ * // src/hooks.client.js
+ * import { stackHandleClientError, withStaleDeployReload } from 'firstly/svelte'
+ *
+ * export const handleError = stackHandleClientError(
+ *   withStaleDeployReload(),
+ *   (next) => (input) => {
+ *     report(input.error) // your logging
+ *     return next(input) // or return { message: 'Oops' } to stop here
+ *   },
+ * )
+ * ```
+ */
+export function stackHandleClientError(
+	...middlewares: HandleClientErrorMiddleware[]
+): HandleClientError {
+	return middlewares.reduceRight<HandleClientError>(
+		(next, mw) => mw(next),
+		() => ({ message: 'Something went wrong' }),
+	)
+}
+
 // Errors SvelteKit/Vite throw when a lazy chunk 404s after a deploy.
 const CHUNK_LOAD_RE =
 	/Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/
@@ -8,31 +40,20 @@ const STORAGE_KEY = 'ff-reload'
 // A URL that failed again within this window is a genuine break, not a stale deploy.
 const RETRY_WINDOW_MS = 10_000
 
-type HandleClientErrorInput = Parameters<HandleClientError>[0]
-
 /**
- * Composable `handleError` for `hooks.client.js` that recovers stale-deploy chunk
- * failures by hard-reloading once, then delegates everything else to your handler.
- *
- * ```js
- * // src/hooks.client.js
- * import { ffHandleError } from 'firstly/svelte'
- *
- * export const handleError = ffHandleError(({ error }) => {
- *   report(error)
- *   return { message: 'Oops' }
- * })
- * ```
- *
- * The reload trusts the failure signal itself, not `updated.check()` (which lies
- * behind a CDN caching `version.json`). A time-boxed one-shot guard prevents loops.
+ * Middleware that recovers stale-deploy chunk failures: after a deploy an open client
+ * (esp. SPA builds) 404s on a lazy chunk. Trusts the failure signal itself, not
+ * `updated.check()` (which lies behind a CDN caching `version.json`), and hard-reloads
+ * once - a time-boxed one-shot guard prevents reload loops. Only chunk-load errors
+ * reload (a blind 404 reload would break client-side not-found routes); anything else
+ * falls through to `next`.
  */
-export function ffHandleError(onError?: HandleClientError): HandleClientError {
-	return (input: HandleClientErrorInput) => {
+export function withStaleDeployReload(): HandleClientErrorMiddleware {
+	return (next) => (input: HandleClientErrorInput) => {
 		if (CHUNK_LOAD_RE.test(String(input.message)) && reloadOnce(input.event.url.href)) {
 			return // page is unloading; no error surfaces
 		}
-		return onError?.(input) ?? { message: 'Something went wrong' }
+		return next(input)
 	}
 }
 

--- a/packages/firstly/src/lib/svelte/handleError.ts
+++ b/packages/firstly/src/lib/svelte/handleError.ts
@@ -4,74 +4,50 @@ import type { HandleClientError } from '@sveltejs/kit'
 const CHUNK_LOAD_RE =
 	/Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/
 
+const STORAGE_KEY = 'ff-reload'
+// A URL that failed again within this window is a genuine break, not a stale deploy.
+const RETRY_WINDOW_MS = 10_000
+
 type HandleClientErrorInput = Parameters<HandleClientError>[0]
-
-export interface FfHandleErrorOptions {
-	/** Matches chunk-load error messages. Default covers Vite/SvelteKit wording. */
-	chunkLoadPattern?: RegExp
-	/** `sessionStorage` key for the one-shot reload guard. Default `ff-reload`. */
-	storageKey?: string
-	/**
-	 * How long (ms) a just-reloaded URL is treated as "already retried". A second
-	 * failure inside this window is a genuine break and falls through to `onError`.
-	 * Default 10000. Avoids needing an `afterNavigate` to clear the guard.
-	 */
-	retryWindowMs?: number
-	/**
-	 * Also treat a bare 404 as a stale-deploy failure. Off by default: it would
-	 * hard-reload legitimate client-side "not found" routes. Turn on for SPA hosts
-	 * where a missing chunk surfaces as a 404 with no chunk-load message.
-	 */
-	recoverOn404?: boolean
-	/** Your own handler for errors that were not recovered (logging, custom UX). */
-	onError?: HandleClientError
-}
-
-const DEFAULT_MESSAGE = 'Something went wrong'
 
 /**
  * Composable `handleError` for `hooks.client.js` that recovers stale-deploy chunk
- * failures by hard-reloading once, then delegates everything else to your `onError`.
+ * failures by hard-reloading once, then delegates everything else to your handler.
  *
  * ```js
  * // src/hooks.client.js
- * export const handleError = ffHandleError({
- *   onError: ({ error }) => { report(error); return { message: 'Oops' } },
+ * import { ffHandleError } from 'firstly/svelte'
+ *
+ * export const handleError = ffHandleError(({ error }) => {
+ *   report(error)
+ *   return { message: 'Oops' }
  * })
  * ```
  *
  * The reload trusts the failure signal itself, not `updated.check()` (which lies
  * behind a CDN caching `version.json`). A time-boxed one-shot guard prevents loops.
  */
-export function ffHandleError(options: FfHandleErrorOptions = {}): HandleClientError {
-	const pattern = options.chunkLoadPattern ?? CHUNK_LOAD_RE
-	const key = options.storageKey ?? 'ff-reload'
-	const windowMs = options.retryWindowMs ?? 10_000
-
+export function ffHandleError(onError?: HandleClientError): HandleClientError {
 	return (input: HandleClientErrorInput) => {
-		const looksStale =
-			(options.recoverOn404 === true && input.status === 404) || pattern.test(String(input.message))
-
-		if (looksStale && reloadOnce(key, windowMs, input.event.url.href)) {
+		if (CHUNK_LOAD_RE.test(String(input.message)) && reloadOnce(input.event.url.href)) {
 			return // page is unloading; no error surfaces
 		}
-
-		return options.onError?.(input) ?? { message: DEFAULT_MESSAGE }
+		return onError?.(input) ?? { message: 'Something went wrong' }
 	}
 }
 
-/** Hard-reload `href` unless it already failed within `windowMs`. Returns true if reloading. */
-function reloadOnce(key: string, windowMs: number, href: string): boolean {
+/** Hard-reload `href` unless it already failed within the guard window. Returns true if reloading. */
+function reloadOnce(href: string): boolean {
 	try {
-		const prev = sessionStorage.getItem(key)
+		const prev = sessionStorage.getItem(STORAGE_KEY)
 		if (prev) {
 			const [prevHref, prevAt] = prev.split('\n')
-			if (prevHref === href && Date.now() - Number(prevAt) < windowMs) {
-				sessionStorage.removeItem(key) // genuine break -> stop retrying
+			if (prevHref === href && Date.now() - Number(prevAt) < RETRY_WINDOW_MS) {
+				sessionStorage.removeItem(STORAGE_KEY) // genuine break -> stop retrying
 				return false
 			}
 		}
-		sessionStorage.setItem(key, `${href}\n${Date.now()}`)
+		sessionStorage.setItem(STORAGE_KEY, `${href}\n${Date.now()}`)
 		location.assign(href) // bypasses SvelteKit's stale version check
 		return true
 	} catch {

--- a/packages/firstly/src/lib/svelte/handleError.ts
+++ b/packages/firstly/src/lib/svelte/handleError.ts
@@ -50,8 +50,7 @@ export function ffHandleError(options: FfHandleErrorOptions = {}): HandleClientE
 
 	return (input: HandleClientErrorInput) => {
 		const looksStale =
-			(options.recoverOn404 === true && input.status === 404) ||
-			pattern.test(String(input.message))
+			(options.recoverOn404 === true && input.status === 404) || pattern.test(String(input.message))
 
 		if (looksStale && reloadOnce(key, windowMs, input.event.url.href)) {
 			return // page is unloading; no error surfaces

--- a/packages/firstly/src/lib/svelte/index.ts
+++ b/packages/firstly/src/lib/svelte/index.ts
@@ -14,7 +14,8 @@ export type {
 } from './ff.svelte.js'
 export { infiniteScroll } from './infiniteScroll.js'
 export type { InfiniteScrollOptions } from './infiniteScroll.js'
-export { ffHandleError } from './handleError.js'
+export { stackHandleClientError, withStaleDeployReload } from './handleError.js'
+export type { HandleClientErrorMiddleware } from './handleError.js'
 export { dialog, ffAutofocus, resolveMessage } from './dialog.svelte.js'
 export type {
 	DialogResult,

--- a/packages/firstly/src/lib/svelte/index.ts
+++ b/packages/firstly/src/lib/svelte/index.ts
@@ -15,7 +15,6 @@ export type {
 export { infiniteScroll } from './infiniteScroll.js'
 export type { InfiniteScrollOptions } from './infiniteScroll.js'
 export { ffHandleError } from './handleError.js'
-export type { FfHandleErrorOptions } from './handleError.js'
 export { dialog, ffAutofocus, resolveMessage } from './dialog.svelte.js'
 export type {
 	DialogResult,

--- a/packages/firstly/src/lib/svelte/index.ts
+++ b/packages/firstly/src/lib/svelte/index.ts
@@ -14,6 +14,8 @@ export type {
 } from './ff.svelte.js'
 export { infiniteScroll } from './infiniteScroll.js'
 export type { InfiniteScrollOptions } from './infiniteScroll.js'
+export { ffHandleError } from './handleError.js'
+export type { FfHandleErrorOptions } from './handleError.js'
 export { dialog, ffAutofocus, resolveMessage } from './dialog.svelte.js'
 export type {
 	DialogResult,


### PR DESCRIPTION
Closes #320

A middleware stack for `hooks.client.js`'s `handleError`, mirroring `stackHttpClient`:

- **`stackHandleClientError(...middlewares)`** - compose error handlers, outermost-first; each middleware short-circuits (return without `next`) or calls `next(input)`. Base returns `{ message: 'Something went wrong' }`.
- **`withStaleDeployReload()`** - built-in middleware that hard-reloads **once** on a chunk-load failure (time-boxed guard, no reload loop), trusting the failure signal instead of `updated.check()` (which lies behind a CDN caching `version.json`). Chunk-load only, so client-side not-found routes aren't reloaded.

```js
// src/hooks.client.js
import { stackHandleClientError, withStaleDeployReload } from 'firstly/svelte'

export const handleError = stackHandleClientError(
  withStaleDeployReload(),
  (next) => (input) => {
    report(input.error)      // your logging
    return next(input)       // or return { message: 'Oops' } to stop here
  },
)
```

Documented in the firstly skill; 6 unit tests.