### PR TITLE
docs(skill): client stack + prod server (compression without breaking SSE)

### DIFF
--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firstly
-description: "firstly - a thin opinionated layer on top of Remult (framework-agnostic, SvelteKit reference). Use when the user mentions firstly, FF_Entity, BaseEnum, the reactive ff layer (ff/FF_Many/FF_One), the cell layer (buildCells/FF_Cell/FF_Grid/GroupFields), firstly modules (mail, cron, changeLog, sqlAdmin), or the boutique copy-paste recipes (auth, grid) - or when building with firstly alongside Remult."
+description: 'firstly - a thin opinionated layer on top of Remult (framework-agnostic, SvelteKit reference). Use when the user mentions firstly, FF_Entity, BaseEnum, the reactive ff layer (ff/FF_Many/FF_One), the cell layer (buildCells/FF_Cell/FF_Grid/GroupFields), firstly modules (mail, cron, changeLog, sqlAdmin), or the boutique copy-paste recipes (auth, grid) - or when building with firstly alongside Remult.'
 ---
 
 # Firstly Patterns
@@ -220,12 +220,13 @@ the read through the API instead.
 ```ts
 // +page.ts (universal) - gated on SSR AND CSR, plain global repo()
 import { remultApiUniversalLoad } from 'firstly/svelte'
+// +page.server.ts - gate a SERVER read (instead of the privileged in-process DB)
+import { remultApiServerLoad } from 'firstly/svelte/server'
+
 export const load = remultApiUniversalLoad(async ({ params }) => ({
 	tasks: await repo(Task).find({ where: { done: false } }),
 }))
 
-// +page.server.ts - gate a SERVER read (instead of the privileged in-process DB)
-import { remultApiServerLoad } from 'firstly/svelte/server'
 export const load = remultApiServerLoad(async () => ({ tasks: await repo(Task).find() }))
 ```
 
@@ -302,16 +303,41 @@ one-shot guard, no reload loop), passing every other error to `next`.
 // src/hooks.client.js
 import { stackHandleClientError, withStaleDeployReload } from 'firstly/svelte'
 
-export const handleError = stackHandleClientError(
-	withStaleDeployReload(),
-	(next) => (input) => {
-		report(input.error) // your logging
-		return next(input) // or return { message: 'Oops' } to stop here
-	},
-)
+export const handleError = stackHandleClientError(withStaleDeployReload(), (next) => (input) => {
+	report(input.error) // your logging
+	return next(input) // or return { message: 'Oops' } to stop here
+})
 ```
 
 Only chunk-load errors reload (a blind 404 reload would break client-side not-found routes).
+
+## Prod server (adapter-node) - compression without breaking SSE
+
+adapter-node ships **no compression** - a data-heavy page can send 100KB+ of uncompressed HTML.
+Wrap the built handler with `@polka/compression` (streaming-safe; gzip by default, `brotli: true`
+to enable), and **bypass remult's SSE endpoint** (`<apiPrefix>/stream`, default `/api/stream`) - a
+compressed/buffered event stream stalls liveQuery, so `'listen'` never updates.
+
+```js
+// scripts/prod-server.js - `node scripts/prod-server.js` (also the Docker CMD)
+import compression from '@polka/compression'
+import polka from 'polka'
+
+import { handler } from '../build/handler.js'
+
+const compress = compression({ threshold: 1024 })
+
+polka()
+	.use((req, res, next) => {
+		if (req.url.startsWith('/api/stream')) return next() // SSE: never compress
+		compress(req, res, next)
+	})
+	.use(handler)
+	.listen(Number(process.env.PORT ?? 3000))
+```
+
+`polka` + `@polka/compression` are runtime deps (not devDeps) - the script imports them in the
+production image.
 
 ## i18n - `LocalizedMessage`
 

--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firstly
-description: 'firstly - a thin opinionated layer on top of Remult (framework-agnostic, SvelteKit reference). Use when the user mentions firstly, FF_Entity, BaseEnum, the reactive ff layer (ff/FF_Many/FF_One), the cell layer (buildCells/FF_Cell/FF_Grid/GroupFields), firstly modules (mail, cron, changeLog, sqlAdmin), or the boutique copy-paste recipes (auth, grid) - or when building with firstly alongside Remult.'
+description: 'firstly - a thin opinionated layer on top of Remult (framework-agnostic, SvelteKit reference). Use when the user mentions firstly, FF_Entity, BaseEnum, the reactive ff layer (ff/FF_Many/FF_One), the cell layer (buildCells/FF_Cell/FF_Grid/GroupFields), firstly modules (mail, cron, changeLog, sqlAdmin), the client stack (stackHttpClient/withShortTermCache/withTabSharing), or the boutique copy-paste recipes (auth, grid) - or when building with firstly alongside Remult.'
 ---
 
 # Firstly Patterns
@@ -144,6 +144,33 @@ API:
 
 - `FF_Allow.owner<T>(col?)` / `FF_Filter.owner<T>(col?)` - owner-only.
 - `FF_Allow.ownerOr<T>({ col?, roles })` / `FF_Filter.ownerOr<T>({ col?, roles })` - admin (or any of `roles`) OR owner.
+
+## Client stack - fetch & SSE middlewares
+
+From root `'firstly'` (pure TS, framework-agnostic). Compose remult's `apiClient` clients from middlewares - typically once in the root layout:
+
+```ts
+import {
+	stackHttpClient,
+	stackSubscriptionClient,
+	withHeader,
+	withShortTermCache,
+	withTabSharing,
+} from 'firstly'
+
+remult.apiClient.httpClient = stackHttpClient(
+	withHeader('X-Correlation-Id', getCorrelationId),
+	withShortTermCache({ ttlMs: 2000 }),
+)
+remult.apiClient.subscriptionClient = stackSubscriptionClient(withTabSharing())
+```
+
+- **`stackHttpClient(...mw)`** - compose `fetch` middlewares (outermost-first) over the base `fetch`. `withHeader(name, getValue)` sets a header when `getValue()` returns a value.
+- **`withShortTermCache({ ttlMs?, shouldCache? })`** - tiny client-side cache: dedupes identical read requests (GET + remult's read-only `__action=get|groupBy` POSTs, keyed by URL+body) within the TTL (default 2000ms). Two components mounting the same query = one network call; failures evicted so the next call retries.
+- **`stackSubscriptionClient(...mw)`** - compose a `SubscriptionClient`, bottoming out at `directSseSubscriptionClient()` (a public mirror of remult's internal SSE client).
+- **`withTabSharing()`** - ONE real SSE connection shared across all same-origin tabs (leader via `navigator.locks`, fanout via `BroadcastChannel`). Why: the browser's ~6-connections-per-domain HTTP/1.1 limit. liveQuery-safe: leader handoff and reconnects fire `onReconnect` in every tab (queries resync); channel interest is refcounted per tab. No-ops in SSR.
+
+(`withShortTermCache` + the subscription stack landed in firstly 0.8 - older versions lack them.)
 
 ## `ff` - reactive layer (Svelte 5)
 


### PR DESCRIPTION
Two skill additions:

- **Client stack** section (stackHttpClient / withShortTermCache / withTabSharing) + description trigger - the code landed in 0.8, the skill never documented it.
- **Prod server (adapter-node)** recipe: compress with @polka/compression but bypass /api/stream so liveQuery keeps streaming.