### PR TITLE
boutique/auth: slide the session cookie on server-side getSession

### DIFF
--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -99,6 +99,8 @@ import { auth } from '$lib/modules/auth/server/module'
 export const api = remultApi({ modules: [auth({ SUPER_ADMIN_EMAILS })] })
 ```
 
+The auth recipe ships `server/sessionCookie.ts` (`getSessionAndSlideCookie` + `forwardAuthSetCookies`), already wired in `server/module.ts` + `server/handle.ts`: a server-side `getSession` alone never refreshes the browser cookie's sliding `Max-Age`, so without it users get force-logged-out at sign-in expiry even mid-session. Keep both wired when customizing.
+
 Full instructions live in each boutique's README.
 
 ## Roles Convention

--- a/packages/firstly/src/boutique/auth/README.md
+++ b/packages/firstly/src/boutique/auth/README.md
@@ -13,9 +13,10 @@ title: Boutique - Auth
 | `entities.ts`                   | `User`, `Session`, `Account`, `Verification` + `Roles_Auth`   |
 | `roles.ts`                      | App-wide `Roles` (merges `Roles_Auth`)                        |
 | `server/auth.ts`                | `betterAuth` instance wired to `remultAdapter`                |
-| `server/handle.ts`              | SvelteKit `handleAuth`                                        |
+| `server/handle.ts`              | SvelteKit `handleAuth` (forwards refreshed session cookies)   |
 | `server/module.ts`              | `auth()` remult Module (entities + `initApi` + `initRequest`) |
 | `server/authHelpers.ts`         | `addRolesToUser(emails, roles)`                               |
+| `server/sessionCookie.ts`       | `getSessionAndSlideCookie` + `forwardAuthSetCookies`          |
 | `svelte/components/Auth.svelte` | Sign up / Sign in / Sign out UI                               |
 
 ## 🚀 Install
@@ -127,6 +128,17 @@ export const auth = betterAuth({
 	},
 })
 ```
+
+## 🍪 Session cookie sliding
+
+better-auth only re-issues the session cookie (sliding `Max-Age`) inside its own endpoints. A server-side `auth.api.getSession()` (like the module's `initRequest`) extends the session in DB but discards the refreshed `Set-Cookie` - so the browser cookie keeps its sign-in expiry and users get force-logged-out after `expiresIn` (7 days by default), even mid-session.
+
+`server/sessionCookie.ts` fixes that ([#327](https://github.com/jycouet/firstly/issues/327)):
+
+- `getSessionAndSlideCookie(auth)` - calls `getSession` with `returnHeaders: true` and stashes any `Set-Cookie` in `event.locals` (via `remult.context.request`). Used by `server/module.ts`.
+- `forwardAuthSetCookies(event, response)` - appends those cookies onto the response. Used by `server/handle.ts`.
+
+Both are already wired - nothing to do. If you're on better-auth <= 1.2.x, `returnHeaders` is missing from the types (works at runtime): add a `@ts-expect-error` on that line.
 
 ## 🧪 Regenerating better-auth entities
 

--- a/packages/firstly/src/boutique/auth/server/handle.ts
+++ b/packages/firstly/src/boutique/auth/server/handle.ts
@@ -4,7 +4,9 @@ import { svelteKitHandler } from 'better-auth/svelte-kit'
 import { building } from '$app/environment'
 
 import { auth } from './auth'
+import { forwardAuthSetCookies } from './sessionCookie'
 
 export const handleAuth: Handle = async ({ event, resolve }) => {
-	return svelteKitHandler({ event, resolve, auth, building })
+	const response = await svelteKitHandler({ event, resolve, auth, building })
+	return forwardAuthSetCookies(event, response)
 }

--- a/packages/firstly/src/boutique/auth/server/module.ts
+++ b/packages/firstly/src/boutique/auth/server/module.ts
@@ -5,6 +5,7 @@ import { authEntities } from '../entities'
 import { Roles } from '../roles'
 import { auth as authConfig } from './auth'
 import { addRolesToUser } from './authHelpers'
+import { getSessionAndSlideCookie } from './sessionCookie'
 
 export const auth = (o?: { SUPER_ADMIN_EMAILS?: string }) =>
 	new Module({
@@ -22,9 +23,7 @@ export const auth = (o?: { SUPER_ADMIN_EMAILS?: string }) =>
 		},
 
 		initRequest: async () => {
-			const s = await authConfig.api.getSession({
-				headers: new Headers(remult.context.headers?.getAll()),
-			})
+			const s = await getSessionAndSlideCookie(authConfig)
 
 			if (s) {
 				const roles = s.user.roles

--- a/packages/firstly/src/boutique/auth/server/sessionCookie.ts
+++ b/packages/firstly/src/boutique/auth/server/sessionCookie.ts
@@ -1,0 +1,43 @@
+import type { RequestEvent } from '@sveltejs/kit'
+
+import { remult } from 'remult'
+
+declare module 'remult' {
+	export interface RemultContext {
+		request?: RequestEvent
+	}
+}
+
+type AuthLocals = { authSetCookies?: string[] }
+
+// better-auth only re-issues the session cookie (sliding Max-Age) inside its
+// endpoint execution. Server-side api.getSession() discards that Set-Cookie,
+// so we capture it here (initRequest) and handleAuth forwards it.
+export async function getSessionAndSlideCookie<
+	TApi extends {
+		getSession: (ctx: { headers: Headers; returnHeaders?: boolean }) => Promise<unknown>
+	},
+>(auth: { api: TApi }) {
+	const { headers, response } = (await auth.api.getSession({
+		headers: new Headers(remult.context.headers?.getAll()),
+		returnHeaders: true,
+	})) as { headers: Headers; response: Awaited<ReturnType<TApi['getSession']>> }
+
+	const setCookies = headers.getSetCookie()
+	if (setCookies.length > 0) {
+		const locals = remult.context.request?.locals as AuthLocals | undefined
+		if (locals) locals.authSetCookies = setCookies
+	}
+
+	return response
+}
+
+export function forwardAuthSetCookies(event: RequestEvent, response: Response) {
+	const setCookies = (event.locals as AuthLocals).authSetCookies
+	if (setCookies?.length && !response.headers.has('set-cookie')) {
+		for (const cookie of setCookies) {
+			response.headers.append('set-cookie', cookie)
+		}
+	}
+	return response
+}


### PR DESCRIPTION
Fixes #327.

better-auth extends the session in DB on a server-side `getSession` but discards the refreshed `Set-Cookie`, so users get force-logged-out at sign-in expiry even mid-session. Adds `server/sessionCookie.ts` (`getSessionAndSlideCookie` + `forwardAuthSetCookies`, proven in production), wires it in `module.ts` / `handle.ts`, and updates the README + skill.