### PR TITLE
feat(svelte): handleCaching - deploy-safe Cache-Control hook

### DIFF
--- a/.changeset/handle-caching.md
+++ b/.changeset/handle-caching.md
@@ -1,0 +1,5 @@
+---
+'firstly': minor
+---
+
+Add `handleCaching` (`firstly/svelte/server`): a `hooks.server.js` handle setting deploy-safe `Cache-Control` headers - immutable for `/_app/immutable/*` 200s, no-store for HTML/API and all non-200s (a cached 404 chunk would brick the client until "disable cache").

--- a/.changeset/handle-caching.md
+++ b/.changeset/handle-caching.md
@@ -1,5 +1,5 @@
 ---
-'firstly': minor
+'firstly': patch
 ---
 
 Add `handleCaching` (`firstly/svelte/server`): a `hooks.server.js` handle setting deploy-safe `Cache-Control` headers - immutable for `/_app/immutable/*` 200s, no-store for HTML/API and all non-200s (a cached 404 chunk would brick the client until "disable cache").

--- a/.claude/skills/firstly/SKILL.md
+++ b/.claude/skills/firstly/SKILL.md
@@ -338,6 +338,23 @@ export const handleError = stackHandleClientError(withStaleDeployReload(), (next
 
 Only chunk-load errors reload (a blind 404 reload would break client-side not-found routes).
 
+## `handleCaching` - deploy-safe `Cache-Control` headers
+
+`handleCaching` (from `firstly/svelte/server`) is the server-side twin of `withStaleDeployReload`:
+a `hooks.server.js` handle that sets `Cache-Control` so browsers/CDNs survive deploys without
+purge-everything. `/_app/immutable/*` (200 only) → immutable 1 year; HTML, API and **every non-200**
+→ `no-cache, no-store, must-revalidate`. Never widen the immutable rule: `/_app/version.json` is not
+hashed, and an immutable **404** (chunk requested mid-deploy) gets cached by the browser for a year -
+a permanent white page only "disable cache" fixes.
+
+```js
+// src/hooks.server.js
+import { sequence } from '@sveltejs/kit/hooks'
+import { handleCaching } from 'firstly/svelte/server'
+
+export const handle = sequence(handleCaching /* , ...rest */)
+```
+
 ## Prod server (adapter-node) - compression without breaking SSE
 
 adapter-node ships **no compression** - a data-heavy page can send 100KB+ of uncompressed HTML.

--- a/packages/firstly/src/lib/svelte/server/handleCaching.spec.ts
+++ b/packages/firstly/src/lib/svelte/server/handleCaching.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { handleCaching } from './handleCaching'
+
+async function run(pathname: string, status = 200) {
+	const response = new Response('x', { status })
+	const event = { url: new URL(`https://app.test${pathname}`) }
+	// @ts-expect-error minimal event
+	const res = await handleCaching({ event, resolve: async () => response })
+	return res.headers.get('Cache-Control')
+}
+
+describe('handleCaching', () => {
+	it('caches hashed assets forever', async () => {
+		expect(await run('/_app/immutable/chunks/abc123.js')).toBe(
+			'public, max-age=31536000, immutable',
+		)
+	})
+
+	it('never caches a 404 chunk (stale-deploy brick)', async () => {
+		expect(await run('/_app/immutable/chunks/gone.js', 404)).toBe(
+			'no-cache, no-store, must-revalidate',
+		)
+	})
+
+	it('keeps version.json and env.js revalidatable', async () => {
+		expect(await run('/_app/version.json')).toBe('no-cache, no-store, must-revalidate')
+		expect(await run('/_app/env.js')).toBeNull() // static asset ext, left to the app
+	})
+
+	it('never caches HTML pages and API responses', async () => {
+		expect(await run('/some/page')).toBe('no-cache, no-store, must-revalidate')
+		expect(await run('/api/tasks')).toBe('no-cache, no-store, must-revalidate')
+	})
+
+	it('leaves other 200 static assets untouched', async () => {
+		expect(await run('/favicon.png')).toBeNull()
+	})
+})

--- a/packages/firstly/src/lib/svelte/server/handleCaching.spec.ts
+++ b/packages/firstly/src/lib/svelte/server/handleCaching.spec.ts
@@ -12,9 +12,7 @@ async function run(pathname: string, status = 200) {
 
 describe('handleCaching', () => {
 	it('caches hashed assets forever', async () => {
-		expect(await run('/_app/immutable/chunks/abc123.js')).toBe(
-			'public, max-age=31536000, immutable',
-		)
+		expect(await run('/_app/immutable/chunks/abc123.js')).toBe('public, max-age=31536000, immutable')
 	})
 
 	it('never caches a 404 chunk (stale-deploy brick)', async () => {

--- a/packages/firstly/src/lib/svelte/server/handleCaching.ts
+++ b/packages/firstly/src/lib/svelte/server/handleCaching.ts
@@ -1,0 +1,39 @@
+import type { Handle } from '@sveltejs/kit'
+
+// Cacheable static assets by extension (used to skip the no-cache header).
+const STATIC_ASSET_RE = /\.(js|css|ico|png|jpg|jpeg|gif|svg|webp|avif|woff2?|ttf|eot)$/
+
+/**
+ * `hooks.server.js` handle that sets `Cache-Control` so browsers and CDNs cache
+ * correctly across deploys - the server-side twin of `withStaleDeployReload`.
+ *
+ * - `/_app/immutable/*` (200 only) → `public, max-age=31536000, immutable`.
+ *   Only this subtree is content-hashed; `/_app/version.json` and `/_app/env.js`
+ *   are not, and MUST stay revalidatable or clients never see a new deploy.
+ * - Everything else non-asset (HTML, API) and every non-200 → `no-cache, no-store,
+ *   must-revalidate`. Never let a 404 carry a long max-age: a chunk 404 during a
+ *   deploy window cached for a year bricks that client until devtools "disable cache".
+ * - Other static assets (200, by extension) are left untouched for you to tune.
+ *
+ * Replaces purge-everything-on-deploy CDN strategies.
+ *
+ * ```js
+ * // src/hooks.server.js
+ * import { sequence } from '@sveltejs/kit/hooks'
+ * import { handleCaching } from 'firstly/svelte/server'
+ *
+ * export const handle = sequence(handleCaching, ...rest)
+ * ```
+ */
+export const handleCaching: Handle = async ({ event, resolve }) => {
+	const response = await resolve(event)
+	const { pathname } = event.url
+
+	if (pathname.startsWith('/_app/immutable/') && response.status === 200) {
+		response.headers.set('Cache-Control', 'public, max-age=31536000, immutable')
+	} else if (response.status !== 200 || !STATIC_ASSET_RE.test(pathname)) {
+		response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate')
+	}
+
+	return response
+}

--- a/packages/firstly/src/lib/svelte/server/index.ts
+++ b/packages/firstly/src/lib/svelte/server/index.ts
@@ -2,6 +2,8 @@ import type { ServerLoadEvent } from '@sveltejs/kit'
 
 import { withRemultFetch } from '../remultApiLoad.js'
 
+export { handleCaching } from './handleCaching.js'
+
 /**
  * Wrap a SvelteKit SERVER load (`+page.server.ts`) so plain global `repo()` reads
  * apply the API gate (as the current user) instead of the privileged DB provider.


### PR DESCRIPTION
Server-side twin of `withStaleDeployReload`: a `hooks.server.js` handle from `firstly/svelte/server`.

- `/_app/immutable/*` 200s -> immutable 1 year; HTML/API and every non-200 -> no-store
- Never caches a 404: an immutable 404 chunk (requested mid-deploy) gets cached by the browser for a year -> permanent white page only devtools "disable cache" fixes