### PR TITLE
fix: apiPrefix on module BackendMethods + mail UI theme tokens + static write toggle

### DIFF
--- a/.changeset/calm-mails-theme.md
+++ b/.changeset/calm-mails-theme.md
@@ -2,6 +2,6 @@
 'firstly': patch
 ---
 
-- BackendMethods of `mail`, `sqlAdmin` and `feedback` now carry an `apiPrefix` (`/api/mail/sendTest`, `/api/sqlAdmin/exec`, ...) so a host app method with the same name (e.g. its own `sendTest`) can no longer shadow them.
+- BackendMethods of `mail`, `sqlAdmin`, `feedback` and `carbone` now carry an `apiPrefix` (`/api/ff/mail/sendTest`, `/api/ff/sqlAdmin/exec`, ...) so a host app method with the same name (e.g. its own `sendTest`) can no longer shadow them.
 - `WriteMail` / `LastMails` read the semantic theme tokens (`bg-card`, `border-border`, `text-primary`, ...) like `SqlAdmin` instead of a hardcoded slate palette.
 - `SqlAdmin`: the write toggle is a static "Allow writes" checkbox; the label no longer flips with the state.

--- a/.changeset/calm-mails-theme.md
+++ b/.changeset/calm-mails-theme.md
@@ -1,0 +1,7 @@
+---
+'firstly': patch
+---
+
+- BackendMethods of `mail`, `sqlAdmin` and `feedback` now carry an `apiPrefix` (`/api/mail/sendTest`, `/api/sqlAdmin/exec`, ...) so a host app method with the same name (e.g. its own `sendTest`) can no longer shadow them.
+- `WriteMail` / `LastMails` read the semantic theme tokens (`bg-card`, `border-border`, `text-primary`, ...) like `SqlAdmin` instead of a hardcoded slate palette.
+- `SqlAdmin`: the write toggle is a static "Allow writes" checkbox; the label no longer flips with the state.

--- a/packages/firstly/src/lib/carbone/CarboneController.ts
+++ b/packages/firstly/src/lib/carbone/CarboneController.ts
@@ -10,7 +10,7 @@ export class CarboneController {
 
 	@BackendMethod({
 		allowed: [Roles_Carbon.Carbon_Admin, Roles_Carbon.Carbon_UploadTemplate],
-		apiPrefix: 'carbone',
+		apiPrefix: 'ff/carbone',
 	})
 	static async uploadTemplate(config: {
 		name: string
@@ -54,7 +54,7 @@ export class CarboneController {
 
 	@BackendMethod({
 		allowed: [Roles_Carbon.Carbon_Admin, Roles_Carbon.Carbon_DownloadTemplate],
-		apiPrefix: 'carbone',
+		apiPrefix: 'ff/carbone',
 	})
 	static async downloadTemplate(config: {
 		templateName?: string
@@ -97,7 +97,7 @@ export class CarboneController {
 
 	@BackendMethod({
 		allowed: [Roles_Carbon.Carbon_Admin, Roles_Carbon.Carbon_DeleteTemplate],
-		apiPrefix: 'carbone',
+		apiPrefix: 'ff/carbone',
 	})
 	static async deleteTemplate(config: { templateId: string }) {
 		const { templateId } = config
@@ -117,7 +117,7 @@ export class CarboneController {
 
 	@BackendMethod({
 		allowed: [Roles_Carbon.Carbon_Admin, Roles_Carbon.Carbon_Render],
-		apiPrefix: 'carbone',
+		apiPrefix: 'ff/carbone',
 	})
 	static async render(config: {
 		templateName?: string

--- a/packages/firstly/src/lib/feedback/FeedbackController.ts
+++ b/packages/firstly/src/lib/feedback/FeedbackController.ts
@@ -69,7 +69,7 @@ async function addMetaData(issueId: string, obj: Record<string, any>) {
 }
 
 export class FeedbackController {
-	@BackendMethod({ allowed: Allow.authenticated })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
 	static async getMilestones() {
 		const data = await getGitHub(
 			`query Milestones(
@@ -111,7 +111,7 @@ export class FeedbackController {
 		)
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
 	static async getIssues(milestoneNumber: number, issueState: 'OPEN' | 'CLOSED') {
 		const issueOrder =
 			issueState === 'CLOSED'
@@ -174,7 +174,7 @@ export class FeedbackController {
 		}) as { id: string; number: number; titleHTML: string; state: string; highlight: boolean }[]
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
 	static async getIssue(issueNumber: number) {
 		const data = await getGitHub(
 			`query Issue($repository: String!, $owner: String!, $issueNumber: Int!) {
@@ -280,7 +280,7 @@ repository(name: $repository, owner: $owner) {
 		return toRet
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
 	static async createIssue(
 		milestoneId: string,
 		title: string,
@@ -357,7 +357,7 @@ repository(name: $repository, owner: $owner) {
 		return toRet
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
 	static async addCommentOnIssue(
 		issueId: string,
 		issueNumber: number,
@@ -418,7 +418,7 @@ repository(name: $repository, owner: $owner) {
 		return 'done'
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
 	static async close(issueId: string, labels: { id: string; name: string }[]) {
 		const inputClose: { issueId: string } = {
 			issueId,
@@ -455,7 +455,7 @@ repository(name: $repository, owner: $owner) {
 		return 'done'
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
 	static async reOpen(issueId: string) {
 		const input: { issueId: string } = {
 			issueId,

--- a/packages/firstly/src/lib/feedback/FeedbackController.ts
+++ b/packages/firstly/src/lib/feedback/FeedbackController.ts
@@ -69,7 +69,7 @@ async function addMetaData(issueId: string, obj: Record<string, any>) {
 }
 
 export class FeedbackController {
-	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'ff/feedback' })
 	static async getMilestones() {
 		const data = await getGitHub(
 			`query Milestones(
@@ -111,7 +111,7 @@ export class FeedbackController {
 		)
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'ff/feedback' })
 	static async getIssues(milestoneNumber: number, issueState: 'OPEN' | 'CLOSED') {
 		const issueOrder =
 			issueState === 'CLOSED'
@@ -174,7 +174,7 @@ export class FeedbackController {
 		}) as { id: string; number: number; titleHTML: string; state: string; highlight: boolean }[]
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'ff/feedback' })
 	static async getIssue(issueNumber: number) {
 		const data = await getGitHub(
 			`query Issue($repository: String!, $owner: String!, $issueNumber: Int!) {
@@ -280,7 +280,7 @@ repository(name: $repository, owner: $owner) {
 		return toRet
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'ff/feedback' })
 	static async createIssue(
 		milestoneId: string,
 		title: string,
@@ -357,7 +357,7 @@ repository(name: $repository, owner: $owner) {
 		return toRet
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'ff/feedback' })
 	static async addCommentOnIssue(
 		issueId: string,
 		issueNumber: number,
@@ -418,7 +418,7 @@ repository(name: $repository, owner: $owner) {
 		return 'done'
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'ff/feedback' })
 	static async close(issueId: string, labels: { id: string; name: string }[]) {
 		const inputClose: { issueId: string } = {
 			issueId,
@@ -455,7 +455,7 @@ repository(name: $repository, owner: $owner) {
 		return 'done'
 	}
 
-	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'feedback' })
+	@BackendMethod({ allowed: Allow.authenticated, apiPrefix: 'ff/feedback' })
 	static async reOpen(issueId: string) {
 		const input: { issueId: string } = {
 			issueId,

--- a/packages/firstly/src/lib/mail/MailController.ts
+++ b/packages/firstly/src/lib/mail/MailController.ts
@@ -22,7 +22,7 @@ export class MailController {
 	 * trimming, lowercasing, and per-entry validation happen here on the
 	 * server - the client just hands over what the user typed.
 	 */
-	@BackendMethod({ allowed: Roles_Mail.Mail_Admin, apiPrefix: 'mail' })
+	@BackendMethod({ allowed: Roles_Mail.Mail_Admin, apiPrefix: 'ff/mail' })
 	static async sendTest(input: {
 		to: string
 		cc?: string

--- a/packages/firstly/src/lib/mail/MailController.ts
+++ b/packages/firstly/src/lib/mail/MailController.ts
@@ -22,7 +22,7 @@ export class MailController {
 	 * trimming, lowercasing, and per-entry validation happen here on the
 	 * server - the client just hands over what the user typed.
 	 */
-	@BackendMethod({ allowed: Roles_Mail.Mail_Admin })
+	@BackendMethod({ allowed: Roles_Mail.Mail_Admin, apiPrefix: 'mail' })
 	static async sendTest(input: {
 		to: string
 		cc?: string

--- a/packages/firstly/src/lib/mail/ui/LastMails.svelte
+++ b/packages/firstly/src/lib/mail/ui/LastMails.svelte
@@ -75,25 +75,25 @@
 	}
 
 	function badgeClass(status: Mail['status']): string {
-		if (status === 'sent') return 'bg-emerald-500/10 border-emerald-500/40 text-emerald-300'
+		if (status === 'sent') return 'bg-emerald-500/10 border-emerald-500/40 text-emerald-700'
 		if (status === 'transport_not_configured')
-			return 'bg-amber-500/10 border-amber-500/40 text-amber-300'
-		return 'bg-red-500/10 border-red-500/40 text-red-300'
+			return 'bg-amber-500/10 border-amber-500/40 text-amber-700'
+		return 'bg-destructive/10 border-destructive text-destructive'
 	}
 </script>
 
-<div class="border border-slate-700 bg-slate-800 text-slate-200">
-	<header class="flex flex-wrap items-center gap-3 border-b border-slate-700 px-5 py-4">
+<div class="border border-border bg-card text-card-foreground">
+	<header class="flex flex-wrap items-center gap-3 border-b border-border px-5 py-4">
 		<div class="flex flex-col">
-			<h2 class="text-lg font-semibold text-slate-100">Last mails</h2>
-			<p class="text-sm text-slate-400">Recent mails sent through this app.</p>
+			<h2 class="text-lg font-semibold text-foreground">Last mails</h2>
+			<p class="text-sm text-muted-foreground">Recent mails sent through this app.</p>
 		</div>
 		{#if hasAccess}
 			<button
 				type="button"
 				onclick={refresh}
 				disabled={isLoading}
-				class="ml-auto inline-flex items-center gap-2 border border-slate-600 bg-slate-700 px-3 py-1.5 text-sm font-medium text-slate-100 hover:bg-slate-600 disabled:opacity-50"
+				class="ml-auto inline-flex items-center gap-2 border border-border bg-secondary px-3 py-1.5 text-sm font-medium text-secondary-foreground hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
 			>
 				{#if isLoading}
 					<svg
@@ -111,24 +111,26 @@
 				{/if}
 				Refresh
 			</button>
-			<span class="text-xs text-slate-500">
+			<span class="text-xs text-muted-foreground">
 				{mails.length} mail{mails.length === 1 ? '' : 's'}
-				{#if live}<span class="text-indigo-400">· live</span>{/if}
+				{#if live}<span class="text-primary">· live</span>{/if}
 			</span>
 		{/if}
 	</header>
 
 	<div class="p-5">
 		{#if !hasAccess}
-			<div class="border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-200">
+			<div class="border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
 				You need the
-				<code class="bg-amber-500/20 px-1 py-0.5 text-xs text-amber-100">Mail.Admin</code>
+				<code class="bg-amber-500/20 px-1 py-0.5 text-xs text-amber-800">Mail.Admin</code>
 				role to use this.
 			</div>
 		{:else if error}
-			<div class="border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">{error}</div>
+			<div class="border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+				{error}
+			</div>
 		{:else if mails.length === 0}
-			<div class="border border-slate-700 bg-slate-900 p-3 text-sm text-slate-400">No mails yet.</div>
+			<div class="border border-border bg-muted p-3 text-sm text-muted-foreground">No mails yet.</div>
 		{:else}
 			<div class="flex flex-col gap-3">
 				{#each mails as m (m.id)}
@@ -137,24 +139,24 @@
 					{@const bcc = formatList(m.metadata?.bcc)}
 					{@const messageId = m.metadata?.transport?.messageId as string | undefined}
 					{@const preview = m.metadata?.transport?.preview as string | undefined}
-					<article class="flex flex-col gap-2 border border-slate-700 bg-slate-900 p-4">
+					<article class="flex flex-col gap-2 border border-border bg-background p-4">
 						<div class="flex flex-wrap items-center gap-2">
 							<span class="border px-2 py-0.5 text-xs font-medium {badgeClass(m.status)}">{m.status}</span>
 							<span
-								class="border border-slate-600 bg-slate-700/50 px-2 py-0.5 text-xs font-medium text-slate-200"
+								class="border border-border bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
 								>{m.topic}</span
 							>
-							<span class="text-xs text-slate-400">{parseTo(m.to)}</span>
-							<span class="ml-auto text-xs text-slate-500">{formatDate(m.createdAt)}</span>
+							<span class="text-xs text-muted-foreground">{parseTo(m.to)}</span>
+							<span class="ml-auto text-xs text-muted-foreground">{formatDate(m.createdAt)}</span>
 						</div>
 
-						<div class="text-base font-medium text-slate-100">{subject || '(no subject)'}</div>
+						<div class="text-base font-medium text-foreground">{subject || '(no subject)'}</div>
 
 						{#if cc}
-							<div class="text-xs text-slate-500">cc: {cc}</div>
+							<div class="text-xs text-muted-foreground">cc: {cc}</div>
 						{/if}
 						{#if bcc}
-							<div class="text-xs text-slate-500">bcc: {bcc}</div>
+							<div class="text-xs text-muted-foreground">bcc: {bcc}</div>
 						{/if}
 
 						{#if preview}
@@ -163,18 +165,18 @@
 									href={preview}
 									target="_blank"
 									rel="noopener noreferrer"
-									class="text-indigo-400 underline hover:text-indigo-300">preview (mail not really sent)</a
+									class="text-primary underline hover:opacity-80">preview (mail not really sent)</a
 								>
 							</div>
 						{/if}
 
 						{#if messageId}
-							<div class="text-xs break-all text-slate-500">id: <code>{messageId}</code></div>
+							<div class="text-xs break-all text-muted-foreground">id: <code>{messageId}</code></div>
 						{/if}
 
 						{#if m.status === 'error' && m.errorInfo}
 							<pre
-								class="border border-red-500/40 bg-red-500/10 p-2 text-xs whitespace-pre-wrap text-red-200">{m.errorInfo}</pre>
+								class="border border-destructive bg-destructive/10 p-2 text-xs whitespace-pre-wrap text-destructive">{m.errorInfo}</pre>
 						{/if}
 					</article>
 				{/each}

--- a/packages/firstly/src/lib/mail/ui/WriteMail.svelte
+++ b/packages/firstly/src/lib/mail/ui/WriteMail.svelte
@@ -47,24 +47,27 @@
 	}
 </script>
 
-<div class="border border-slate-700 bg-slate-800 text-slate-200">
-	<header class="border-b border-slate-700 px-5 py-4">
-		<h2 class="text-lg font-semibold text-slate-100">Write mail</h2>
-		<p class="mt-1 text-sm text-slate-400">Send a test mail through the configured transport.</p>
+<div class="border border-border bg-card text-card-foreground">
+	<header class="border-b border-border px-5 py-4">
+		<h2 class="text-lg font-semibold text-foreground">Write mail</h2>
+		<p class="mt-1 text-sm text-muted-foreground">
+			Send a test mail through the configured transport.
+		</p>
 	</header>
 
 	<div class="p-5">
 		{#if !hasAccess}
-			<div class="border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-200">
+			<div class="border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700">
 				You need the
-				<code class="bg-amber-500/20 px-1 py-0.5 text-xs text-amber-100">Mail.Admin</code>
+				<code class="bg-amber-500/20 px-1 py-0.5 text-xs text-amber-800">Mail.Admin</code>
 				role to use this.
 			</div>
 		{:else}
 			<form onsubmit={handleSubmit} class="flex flex-col gap-4">
 				<div class="flex flex-col gap-1">
-					<label for="write-mail-to" class="text-xs font-medium tracking-wide text-slate-400 uppercase"
-						>To</label
+					<label
+						for="write-mail-to"
+						class="text-xs font-medium tracking-wide text-muted-foreground uppercase">To</label
 					>
 					<input
 						id="write-mail-to"
@@ -72,14 +75,15 @@
 						bind:value={to}
 						disabled={isLoading}
 						placeholder="someone@example.com, other@example.com"
-						class="border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-indigo-400 focus:outline-none disabled:opacity-50"
+						class="border border-input bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none disabled:opacity-50"
 					/>
 				</div>
 
 				<div class="grid grid-cols-2 gap-4 max-md:grid-cols-1">
 					<div class="flex flex-col gap-1">
-						<label for="write-mail-cc" class="text-xs font-medium tracking-wide text-slate-400 uppercase"
-							>Cc</label
+						<label
+							for="write-mail-cc"
+							class="text-xs font-medium tracking-wide text-muted-foreground uppercase">Cc</label
 						>
 						<input
 							id="write-mail-cc"
@@ -87,12 +91,13 @@
 							bind:value={cc}
 							disabled={isLoading}
 							placeholder="optional, comma-separated"
-							class="border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-indigo-400 focus:outline-none disabled:opacity-50"
+							class="border border-input bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none disabled:opacity-50"
 						/>
 					</div>
 					<div class="flex flex-col gap-1">
-						<label for="write-mail-bcc" class="text-xs font-medium tracking-wide text-slate-400 uppercase"
-							>Bcc</label
+						<label
+							for="write-mail-bcc"
+							class="text-xs font-medium tracking-wide text-muted-foreground uppercase">Bcc</label
 						>
 						<input
 							id="write-mail-bcc"
@@ -100,7 +105,7 @@
 							bind:value={bcc}
 							disabled={isLoading}
 							placeholder="optional, comma-separated"
-							class="border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-indigo-400 focus:outline-none disabled:opacity-50"
+							class="border border-input bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none disabled:opacity-50"
 						/>
 					</div>
 				</div>
@@ -108,7 +113,7 @@
 				<div class="flex flex-col gap-1">
 					<label
 						for="write-mail-subject"
-						class="text-xs font-medium tracking-wide text-slate-400 uppercase">Subject</label
+						class="text-xs font-medium tracking-wide text-muted-foreground uppercase">Subject</label
 					>
 					<input
 						id="write-mail-subject"
@@ -117,28 +122,29 @@
 						disabled={isLoading}
 						required
 						placeholder="Subject"
-						class="border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-indigo-400 focus:outline-none disabled:opacity-50"
+						class="border border-input bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none disabled:opacity-50"
 					/>
 				</div>
 
 				<div class="flex flex-col gap-1">
-					<label for="write-mail-body" class="text-xs font-medium tracking-wide text-slate-400 uppercase"
-						>Body</label
+					<label
+						for="write-mail-body"
+						class="text-xs font-medium tracking-wide text-muted-foreground uppercase">Body</label
 					>
 					<textarea
 						id="write-mail-body"
 						bind:value={body}
 						disabled={isLoading}
 						placeholder="Write your message..."
-						class="h-40 w-full border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-indigo-400 focus:outline-none disabled:opacity-50"
+						class="h-40 w-full border border-input bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-ring focus:outline-none disabled:opacity-50"
 					></textarea>
 				</div>
 
-				<div class="flex items-center gap-4 border-t border-slate-700 pt-4">
+				<div class="flex items-center gap-4 border-t border-border pt-4">
 					<button
 						type="submit"
 						disabled={isLoading || !canSend}
-						class="inline-flex items-center gap-2 bg-indigo-500 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-400 disabled:opacity-50"
+						class="inline-flex items-center gap-2 bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
 					>
 						{#if isLoading}
 							<svg
@@ -158,12 +164,12 @@
 					</button>
 
 					{#if !canSend && !result && !error}
-						<span class="text-xs text-slate-500"> Add a subject and at least one recipient. </span>
+						<span class="text-xs text-muted-foreground"> Add a subject and at least one recipient. </span>
 					{/if}
 
 					{#if result}
 						<div
-							class="flex flex-1 items-center gap-2 border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-sm text-emerald-200"
+							class="flex flex-1 items-center gap-2 border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-sm text-emerald-700"
 						>
 							<span class="font-medium">Sent</span>
 							{#if result.messageId}
@@ -174,7 +180,7 @@
 
 					{#if error}
 						<pre
-							class="flex-1 overflow-auto border border-red-500/40 bg-red-500/10 px-3 py-1.5 text-xs whitespace-pre-wrap text-red-200">{error}</pre>
+							class="flex-1 overflow-auto border border-destructive bg-destructive/10 px-3 py-1.5 text-xs whitespace-pre-wrap text-destructive">{error}</pre>
 					{/if}
 				</div>
 			</form>

--- a/packages/firstly/src/lib/sqlAdmin/SqlAdminController.ts
+++ b/packages/firstly/src/lib/sqlAdmin/SqlAdminController.ts
@@ -14,7 +14,10 @@ export class SqlAdminController {
 	 *   (INSERT/UPDATE/DELETE/DDL). Set `true` only when you deliberately want
 	 *   to mutate - the UI gates this behind an explicit checkbox.
 	 */
-	@BackendMethod({ allowed: [Roles_SqlAdmin.SqlAdmin_Admin, FF_Role.FF_Role_Admin] })
+	@BackendMethod({
+		allowed: [Roles_SqlAdmin.SqlAdmin_Admin, FF_Role.FF_Role_Admin],
+		apiPrefix: 'sqlAdmin',
+	})
 	static async exec(cmd: string, notReadOnly = false) {
 		const db = SqlAdminController.dp ?? SqlDatabase.getDb()
 		const start = performance.now()

--- a/packages/firstly/src/lib/sqlAdmin/SqlAdminController.ts
+++ b/packages/firstly/src/lib/sqlAdmin/SqlAdminController.ts
@@ -16,7 +16,7 @@ export class SqlAdminController {
 	 */
 	@BackendMethod({
 		allowed: [Roles_SqlAdmin.SqlAdmin_Admin, FF_Role.FF_Role_Admin],
-		apiPrefix: 'sqlAdmin',
+		apiPrefix: 'ff/sqlAdmin',
 	})
 	static async exec(cmd: string, notReadOnly = false) {
 		const db = SqlAdminController.dp ?? SqlDatabase.getDb()

--- a/packages/firstly/src/lib/sqlAdmin/ui/SqlAdmin.svelte
+++ b/packages/firstly/src/lib/sqlAdmin/ui/SqlAdmin.svelte
@@ -21,7 +21,7 @@ LIMIT 10`
 	let result: { rows: any[]; rowCount: number; took: number } | undefined = $state()
 	let error = $state('')
 	let isLoading = $state(false)
-	let notReadOnly = $state(false)
+	let allowWrites = $state(false)
 	let copied = $state(false)
 
 	const queries = {
@@ -64,7 +64,7 @@ ORDER BY tablename, indexname`,
 		try {
 			error = ''
 			isLoading = true
-			result = await SqlAdminController.exec(sqlInput, notReadOnly)
+			result = await SqlAdminController.exec(sqlInput, allowWrites)
 			log.info('for AI:', JSON.stringify(result.rows))
 			log.info('for humans:', result)
 		} catch (e) {
@@ -159,14 +159,16 @@ ORDER BY tablename, indexname`,
 					Execute SQL
 				</button>
 
+				<!-- Static label: the checkbox state is the signal, the text never
+					 flips so the user always knows what ticking it does. -->
 				<label
 					class="inline-flex items-center gap-2 text-sm font-medium select-none"
-					class:text-destructive={notReadOnly}
-					class:text-muted-foreground={!notReadOnly}
-					title="Read-only runs your query in a READ ONLY transaction so the database rejects any write. Tick this only when you know what you are doing."
+					class:text-destructive={allowWrites}
+					class:text-muted-foreground={!allowWrites}
+					title="Unchecked: the query runs in a READ ONLY transaction, so the database rejects any write. Tick only when you know what you are doing."
 				>
-					<input type="checkbox" bind:checked={notReadOnly} class="accent-destructive" />
-					{notReadOnly ? 'Writes enabled (I know what I am doing)' : 'Read-only'}
+					<input type="checkbox" bind:checked={allowWrites} class="accent-destructive" />
+					Allow writes
 				</label>
 
 				{#if error}


### PR DESCRIPTION
- Firstly's BackendMethods (`mail`, `sqlAdmin`, `feedback`, `carbone`) now live under `/api/ff/<module>/...`, so a host app method with the same bare name (a `sendTest` push tester shadowed `/api/sendTest` and the mail form got its return value) can no longer hijack them.
- `WriteMail` / `LastMails` read the semantic theme tokens like `SqlAdmin` instead of a hardcoded slate palette.
- `SqlAdmin`: the write toggle is a static "Allow writes" checkbox instead of a label that flips with the state.