### PR TITLE
fix(withShortTermCache): clear cached reads after a mutation

### DIFF
--- a/.changeset/short-term-cache-invalidate.md
+++ b/.changeset/short-term-cache-invalidate.md
@@ -1,0 +1,5 @@
+---
+'firstly': patch
+---
+
+`withShortTermCache`: mutations (POST writes, PUT, PATCH, DELETE) now clear the cache once they settle, so a follow-up refresh no longer serves the pre-mutation read.

--- a/packages/firstly/src/lib/core/httpClientStack.spec.ts
+++ b/packages/firstly/src/lib/core/httpClientStack.spec.ts
@@ -98,6 +98,43 @@ describe('withShortTermCache', () => {
 		expect(seen).toHaveLength(2)
 	})
 
+	it('clears cached reads after a mutation settles', async () => {
+		let calls = 0
+		vi.stubGlobal('fetch', () => {
+			calls++
+			return Promise.resolve(new Response('ok'))
+		})
+
+		const client = stackHttpClient(withShortTermCache({ ttlMs: 10_000 }))
+		await client('/api/tasks')
+		await client('/api/tasks')
+		expect(calls).toBe(1)
+
+		await client('/api/tasks', { method: 'POST', body: '{}' })
+		await client('/api/tasks')
+		expect(calls).toBe(3)
+
+		await client('/api/tasks/1', { method: 'DELETE' })
+		await client('/api/tasks')
+		expect(calls).toBe(5)
+	})
+
+	it('clears cached reads even when the mutation fails', async () => {
+		let calls = 0
+		vi.stubGlobal('fetch', (_i: RequestInfo | URL, init?: RequestInit) => {
+			calls++
+			return init?.method === 'PUT'
+				? Promise.reject(new Error('boom'))
+				: Promise.resolve(new Response('ok'))
+		})
+
+		const client = stackHttpClient(withShortTermCache({ ttlMs: 10_000 }))
+		await client('/api/tasks')
+		await expect(client('/api/tasks/1', { method: 'PUT', body: '{}' })).rejects.toThrow('boom')
+		await client('/api/tasks')
+		expect(calls).toBe(3)
+	})
+
 	it('evicts failed requests so the next call retries', async () => {
 		let calls = 0
 		vi.stubGlobal('fetch', () => {

--- a/packages/firstly/src/lib/core/httpClientStack.ts
+++ b/packages/firstly/src/lib/core/httpClientStack.ts
@@ -52,7 +52,8 @@ const defaultShouldCache: NonNullable<ShortTermCacheOptions['shouldCache']> = (
  * Middleware that dedupes identical read requests within a short TTL - a tiny
  * client-side cache. Two components mounting and issuing the same query result in
  * ONE network call; each caller gets its own `Response` clone. Failed requests are
- * evicted immediately so the next call retries.
+ * evicted immediately so the next call retries. Any mutation (non-GET that isn't a
+ * cached read) clears the cache once it settles, so a follow-up refresh sees fresh data.
  *
  * ```ts
  * remult.apiClient.httpClient = stackHttpClient(withShortTermCache({ ttlMs: 2000 }))
@@ -77,7 +78,16 @@ export function withShortTermCache(opts: ShortTermCacheOptions = {}): HttpClient
 		}
 
 		if (!shouldCache(input, init, cacheKey)) {
-			return next(input, init)
+			const method = init?.method?.toUpperCase() ?? 'GET'
+			if (method === 'GET') return next(input, init)
+			// Mutation: drop cached reads once it settles (not before, so a read racing the
+			// write can't re-cache pre-mutation data). Cleared on error too: the server may
+			// have partially mutated.
+			try {
+				return await next(input, init)
+			} finally {
+				cache.clear()
+			}
 		}
 
 		const now = Date.now()


### PR DESCRIPTION
Closes #343.

Any request that isn't a cached read (POST write, PUT, PATCH, DELETE) clears the cache once it settles - after the response, so a read racing the write can't re-cache pre-mutation data; on error too, since the server may have partially mutated. A `refresh()` right after an insert now sees the new row.