### PR TITLE
fix(feedback): getIssues empty when labels_filters is unset

### DIFF
--- a/.changeset/feedback-empty-labels.md
+++ b/.changeset/feedback-empty-labels.md
@@ -1,0 +1,5 @@
+---
+'firstly': patch
+---
+
+feedback: `getIssues` returned nothing when `milestones.labels_filters` was unset (GitHub treats `labels: []` as "match nothing"); the filter is now omitted in that case.

--- a/packages/firstly/src/lib/feedback/FeedbackController.ts
+++ b/packages/firstly/src/lib/feedback/FeedbackController.ts
@@ -153,7 +153,10 @@ export class FeedbackController {
 				owner: remult.context.feedbackOptions.repo.owner,
 				milestoneNumber,
 				filters: {
-					labels: remult.context.feedbackOptions.milestones?.labels_filters ?? [],
+					// GitHub treats `labels: []` as "match nothing", so omit the key when unset.
+					labels: remult.context.feedbackOptions.milestones?.labels_filters?.length
+						? remult.context.feedbackOptions.milestones.labels_filters
+						: undefined,
 					states: [issueState],
 				},
 				issueOrder,


### PR DESCRIPTION
GitHub's `IssueFilters.labels: []` matches nothing, so `getIssues` always returned `[]` unless `milestones.labels_filters` was set. The key is now omitted when unset/empty.